### PR TITLE
fix: indendation in mode mapping

### DIFF
--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -240,8 +240,8 @@ class IntesisAC(ClimateEntity):
             for mode in modes:
                 if mode in MAP_IH_TO_HVAC_MODE:
                     mode_list.append(MAP_IH_TO_HVAC_MODE[mode])
-            else:
-                _LOGGER.warning("Unexpected mode: %s", mode)
+                else:
+                    _LOGGER.warning("Unexpected mode: %s", mode)
             self._attr_hvac_modes.extend(mode_list)
         self._attr_hvac_modes.append(HVACMode.OFF)
 


### PR DESCRIPTION
`for`/`else` is valid python, but is only useful in conjunction with `break`, and is not the intention with this piece of code
