### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -17,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
+        hass.config_entries.async_forward_entry_setups(entry, "climate")
     )
 
     return True


### PR DESCRIPTION
Changed hass.config_entries.async_forward_entry_setup to hass.config_entries.async_forward_entry_setups to resolve warning in Home Assistant Logs.

Per logs, "setup" will stop working in Home Assistant 2025.1.

Closes #15 