### PR TITLE
(fix) fixes HACS workflows

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,8 +1,9 @@
 name: Validate with hassfest
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [master]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   validate-hacs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,20 +6,10 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
+  validate-hacs:
+    runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
-
-  validate_hacs:
-    name: "HACS Validation"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: "actions/checkout@v3"
-      - name: HACS Action
+      - name: HACS validation
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: "brands topics"

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,3 @@
 {
-    "name": "IntesisHome (Config flow)",
+    "name": "IntesisHome (Config flow)"
 }


### PR DESCRIPTION
The current HACS CI workflows fail. This PR fixes them by:
- using the standard HACS validation workflow (see https://hacs.xyz/docs/publish/action/)
- Removing a trailing `,` in `hacs.json`

It also makes sure that the workflows are only trigger by a PR or a direct push on the `master` branch.