### PR TITLE
Added device with deviceInfo based on device name, type, model and firmware version

### DIFF
--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -581,8 +581,11 @@ class IntesisAC(ClimateEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         controller_model = None
+        controller_fw_version = None
         if hasattr(self._controller, "get_model"):
             controller_model = self._controller.get_model(self._device_id)
+        if hasattr(self._controller, "get_fw_version"):
+            controller_fw_version = self._controller.get_fw_version(self._device_id)
         return DeviceInfo(
             identifiers={
                 # Serial numbers are unique identifiers within a specific domain
@@ -590,5 +593,6 @@ class IntesisAC(ClimateEntity):
             },
             name=self._device_name,
             manufacturer=self._device_type.capitalize(),
-            model=controller_model
+            model=controller_model,
+            sw_version=controller_fw_version
         )

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -589,6 +589,6 @@ class IntesisAC(ClimateEntity):
                 (DOMAIN, self._controller.controller_id, self._device_id) 
             },
             name=self._device_name,
-            manufacturer=self._device_type,
+            manufacturer=self._device_type.capitalize(),
             model=controller_model
         )

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -48,6 +48,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity import DeviceInfo
 
 
 from . import DOMAIN
@@ -111,7 +112,7 @@ async def async_setup_entry(
                     IntesisAC(ih_device_id, device, controller)
                     for ih_device_id, device in ih_devices.items()
                 ],
-                update_before_add=True,
+                update_before_add=False,
             )
     else:
         await async_setup_platform(hass, config, async_add_entities)
@@ -575,3 +576,19 @@ class IntesisAC(ClimateEntity):
         if self._power and self.hvac_mode not in [HVACMode.FAN_ONLY, HVACMode.OFF]:
             return self._target_temp
         return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        controller_model = None
+        if hasattr(self._controller, "get_model"):
+            controller_model = self._controller.get_model(self._device_id)
+        return DeviceInfo(
+            identifiers={
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self._controller.controller_id, self._device_id) 
+            },
+            name=self._device_name,
+            manufacturer=self._device_type,
+            model=controller_model
+        )


### PR DESCRIPTION
This change creates a device per entity with the device name, it's type (based on the sub integration type: airconwithme / intesishome_local as manufacturer) and the model. Model is derived from the controller, if new get_model function (see https://github.com/jnimmo/pyIntesisHome/pull/59) is available (otherwise it's none / unknown). Firmware version is derived from the controller for intesishome device, if new get_fw_version function is available (see https://github.com/jnimmo/pyIntesisHome/pull/59) otherwise it's none.

Devices view:
![image](https://github.com/user-attachments/assets/b41d56e1-af96-474e-bbbf-6729cbb5244b)

Per device:
![image](https://github.com/user-attachments/assets/681244b6-2a2c-4328-a84f-b4a2a0cc5077)

New function in pyIntesishome unavailable:
![image](https://github.com/user-attachments/assets/37212589-4c83-4b04-b0d0-853ee34c2a95)

Also change `update_before_add=True` to `update_before_add=False` in `async_setup_entry` to prevent issues during startup when using multiple airconwithme devices.