### PR TITLE
Lifecycle refactor + merge swing-modes PR #27 + error surfacing

### DIFF
--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -2,6 +2,19 @@
 """The IntesisHome integration."""
 from __future__ import annotations
 
+import sys as _sys
+from pathlib import Path as _Path
+
+_vendor_path = _Path(__file__).parent / "_vendor"
+if _vendor_path.is_dir():
+    _vendor_str = str(_vendor_path)
+    if _vendor_str not in _sys.path:
+        _sys.path.insert(0, _vendor_str)
+    for _name in list(_sys.modules):
+        if _name == "pyintesishome" or _name.startswith("pyintesishome."):
+            del _sys.modules[_name]
+del _sys, _Path, _vendor_path
+
 import asyncio
 import logging
 

--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -2,18 +2,6 @@
 """The IntesisHome integration."""
 from __future__ import annotations
 
-import sys as _sys
-from pathlib import Path as _Path
-
-_vendor_path = _Path(__file__).parent / "_vendor"
-if _vendor_path.is_dir():
-    _vendor_str = str(_vendor_path)
-    if _vendor_str not in _sys.path:
-        _sys.path.insert(0, _vendor_str)
-    for _name in list(_sys.modules):
-        if _name == "pyintesishome" or _name.startswith("pyintesishome."):
-            del _sys.modules[_name]
-del _sys, _Path, _vendor_path
 
 import logging
 

--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -3,34 +3,107 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+
+from pyintesishome import (
+    IHAuthenticationError,
+    IHConnectionError,
+    IntesisBase,
+    IntesisBox,
+    IntesisHome,
+    IntesisHomeLocal,
+)
+from pyintesishome.const import (
+    DEVICE_INTESISBOX,
+    DEVICE_INTESISHOME_LOCAL,
+)
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 DOMAIN = "intesishome"
 PLATFORMS = ["climate"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up IntesisHome from a config entry."""
+    """Set up IntesisHome from a config entry.
+
+    Constructs the shared controller, performs the initial poll, and stores
+    the controller on hass.data so each platform (climate, select, ...)
+    works against the same TCP session.
+    """
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
+    config = entry.data
+    ih_user = config.get(CONF_USERNAME)
+    ih_host = config.get(CONF_HOST)
+    ih_pass = config.get(CONF_PASSWORD)
+    device_type = config.get(CONF_DEVICE)
+    websession = async_get_clientsession(hass)
 
+    controller: IntesisBase
+    if device_type == DEVICE_INTESISBOX:
+        controller = IntesisBox(ih_host, loop=hass.loop)
+    elif device_type == DEVICE_INTESISHOME_LOCAL:
+        controller = IntesisHomeLocal(
+            ih_host, ih_user, ih_pass, loop=hass.loop, websession=websession
+        )
+    else:
+        controller = IntesisHome(
+            ih_user,
+            ih_pass,
+            hass.loop,
+            websession=websession,
+            device_type=device_type,
+        )
+
+    # Authenticate and bring the connection up in one shot. Doing it here
+    # (rather than in the entity's async_added_to_hass) avoids a
+    # duplicate HTTP poll_status, gives the platforms a fully-live
+    # controller, and removes the race that produced the "Setup of
+    # climate platform taking over 10 seconds" warning during HA boot.
+    try:
+        await controller.connect()
+    except IHAuthenticationError as exc:
+        _LOGGER.error("Invalid IntesisHome credentials for %s", device_type)
+        raise ConfigEntryAuthFailed from exc
+    except IHConnectionError as exc:
+        _LOGGER.error("Error connecting to the %s server: %s", device_type, exc)
+        raise ConfigEntryNotReady from exc
+
+    if not controller.get_devices():
+        await controller.stop()
+        _LOGGER.error(
+            "No devices returned from %s API: %s",
+            device_type,
+            controller.error_message,
+        )
+        raise ConfigEntryNotReady("No devices returned from API")
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "config": entry.data,
+        "controller": controller,
+    }
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    # example
-    # unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    unload_ok = all(
-        await asyncio.gather(
-            *[hass.config_entries.async_forward_entry_unload(entry, "climate")]
-        )
-    )
+    """Unload a config entry and stop the controller."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
+        data = hass.data[DOMAIN].pop(entry.entry_id, None)
+        if data and (controller := data.get("controller")):
+            await controller.stop()
     return unload_ok

--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -15,7 +15,6 @@ if _vendor_path.is_dir():
             del _sys.modules[_name]
 del _sys, _Path, _vendor_path
 
-import asyncio
 import logging
 
 from pyintesishome import (

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -29,9 +29,7 @@ from homeassistant.components.climate import (
     PRESET_BOOST,
     PRESET_COMFORT,
     PRESET_ECO,
-    SWING_HORIZONTAL,
     SWING_OFF,
-    SWING_VERTICAL,
     ClimateEntityFeature,
     HVACMode,
 )
@@ -229,20 +227,43 @@ class IntesisAC(ClimateEntity):
         if controller.has_setpoint_control(ih_device_id):
             self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
-        # Setup swing list
+        # Setup swing lists
         if controller.has_vertical_swing(ih_device_id):
-            self._swing_list.extend([
-                "Swing",
-                "Position1",
-                "Position2",
-                "Position3", 
-                "Position4"
-            ])
+            if hasattr(controller, "get_vertical_swing_list"):
+                if swingmodes := controller.get_vertical_swing_list(ih_device_id):
+                    swingmode_list = []
+                    for swingmode in swingmodes:
+                        if swingmode in MAP_IH_TO_SWING:
+                            swingmode_list.append(MAP_IH_TO_SWING[swingmode])
+                        else:
+                            _LOGGER.warning("Unexpected swingmode: %s", swingmode)
+                    self._swing_list.extend(swingmode_list)
+            else:
+                self._swing_list.extend([
+                    "Swing",
+                    "Position1",
+                    "Position2",
+                    "Position3", 
+                    "Position4"
+                ])
         if controller.has_horizontal_swing(ih_device_id):
-            self._swing_horizontal_list.extend([
-                SWING_OFF,
-                SWING_HORIZONTAL
-            ])
+            if hasattr(controller, "get_horizontal_swing_list"):
+                if swingmodes := controller.get_horizontal_swing_list(ih_device_id):
+                    swingmode_list = []
+                    for swingmode in swingmodes:
+                        if swingmode in MAP_IH_TO_SWING:
+                            swingmode_list.append(MAP_IH_TO_HORIZONTAL_SWING[swingmode])
+                        else:
+                            _LOGGER.warning("Unexpected swingmode: %s", swingmode)
+                    self._swing_horizontal_list.extend(swingmode_list)
+            else:
+                self._swing_list.extend([
+                    "Swing",
+                    "Position1",
+                    "Position2",
+                    "Position3", 
+                    "Position4"
+                ])
         if len(self._swing_list) > 0:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
         if len(self._swing_horizontal_list) > 0:

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -3,24 +3,8 @@
 from __future__ import annotations
 
 import logging
-from random import randrange
-from typing import NamedTuple
 
-from pyintesishome import (
-    IHAuthenticationError,
-    IHConnectionError,
-    IntesisBase,
-    IntesisBox,
-    IntesisHome,
-    IntesisHomeLocal,
-)
-from pyintesishome.const import (
-    DEVICE_AIRCONWITHME,
-    DEVICE_ANYWAIR,
-    DEVICE_INTESISBOX,
-    DEVICE_INTESISHOME,
-    DEVICE_INTESISHOME_LOCAL,
-)
+from pyintesishome import IntesisBase
 
 from homeassistant import config_entries, core
 from homeassistant.components.climate import ClimateEntity
@@ -35,20 +19,9 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_DEVICE,
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    UnitOfTemperature,
-)
-from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
 
 from . import DOMAIN
 
@@ -91,84 +64,25 @@ MAP_STATE_ICONS = {
     HVACMode.HEAT_COOL: "mdi:cached",
 }
 
-MAX_RETRIES = 10
-MAX_WAIT_TIME = 300
-
-
 async def async_setup_entry(
     hass: core.HomeAssistant,
     config_entry: config_entries.ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Create climate entities from config flow."""
-    config = config_entry.data
-    if "controller" in hass.data[DOMAIN]:
-        controller = hass.data[DOMAIN]["controller"].pop(config_entry.unique_id)
-        ih_devices = controller.get_devices()
-        if ih_devices:
-            async_add_entities(
-                [
-                    IntesisAC(ih_device_id, device, controller)
-                    for ih_device_id, device in ih_devices.items()
-                ],
-                update_before_add=True,
-            )
-    else:
-        await async_setup_platform(hass, config, async_add_entities)
+    """Create climate entities from config flow.
 
-
-async def async_setup_platform(
-    hass: core.HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None
-) -> None:
-    """Create the IntesisHome climate devices."""
-    ih_user = config.get(CONF_USERNAME)
-    ih_host = config.get(CONF_HOST)
-    ih_pass = config.get(CONF_PASSWORD)
-    device_type = config.get(CONF_DEVICE)
-    websession = async_get_clientsession(hass)
-
-    if device_type == DEVICE_INTESISBOX:
-        controller = IntesisBox(config[CONF_HOST], loop=hass.loop)
-        await controller.connect()
-    elif device_type == DEVICE_INTESISHOME_LOCAL:
-        controller = IntesisHomeLocal(
-            ih_host, ih_user, ih_pass, loop=hass.loop, websession=websession
-        )
-    else:
-        controller = IntesisHome(
-            ih_user,
-            ih_pass,
-            hass.loop,
-            websession=async_get_clientsession(hass),
-            device_type=device_type,
-        )
-    try:
-        await controller.poll_status()
-    except IHAuthenticationError:
-        _LOGGER.error("Invalid username or password")
-        return
-    except IHConnectionError as ex:
-        _LOGGER.error("Error connecting to the %s server", device_type)
-        raise PlatformNotReady from ex
-
-    if ih_devices := controller.get_devices():
-        async_add_entities(
-            [
-                IntesisAC(ih_device_id, device, controller)
-                for ih_device_id, device in ih_devices.items()
-            ],
-            update_before_add=False,
-        )
-    else:
-        _LOGGER.error(
-            "Error getting device list from %s API: %s",
-            device_type,
-            controller.error_message,
-        )
-        await controller.stop()
+    The controller is constructed in __init__.async_setup_entry and stored
+    on hass.data so every platform shares one TCP session.
+    """
+    controller: IntesisBase = hass.data[DOMAIN][config_entry.entry_id]["controller"]
+    ih_devices = controller.get_devices() or {}
+    async_add_entities(
+        [
+            IntesisAC(ih_device_id, device, controller)
+            for ih_device_id, device in ih_devices.items()
+        ],
+        update_before_add=True,
+    )
 
 
 # pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-public-methods
@@ -246,16 +160,14 @@ class IntesisAC(ClimateEntity):
         self._attr_hvac_modes.append(HVACMode.OFF)
 
     async def async_added_to_hass(self):
-        """Subscribe to event updates."""
+        """Subscribe to event updates.
+
+        The controller is already connected by the time the entity is
+        added (see __init__.async_setup_entry) so this only needs to
+        register the state-update callback.
+        """
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
         self._controller.add_update_callback(self.async_update_callback)
-
-        if self._device_type is not DEVICE_INTESISBOX:
-            try:
-                await self._controller.connect()
-            except IHConnectionError as ex:
-                _LOGGER.error("Exception connecting to IntesisHome: %s", ex)
-                raise PlatformNotReady from ex
 
     @property
     def name(self):
@@ -449,49 +361,11 @@ class IntesisAC(ClimateEntity):
 
     async def async_update_callback(self, device_id=None):
         """Let HA know there has been an update from the controller."""
-        # Track changes in connection state
+        # Track connection-state transitions for logging.
         if self._controller and not self._controller.is_connected and self._connected:
-            # Connection has dropped
             self._connected = False
-            reconnect_seconds = 30
-            if self._device_type in [
-                DEVICE_INTESISHOME,
-                DEVICE_ANYWAIR,
-                DEVICE_AIRCONWITHME,
-            ]:
-                # Add a random delay for cloud connections
-                reconnect_seconds = randrange(30, 600)
-
-            _LOGGER.info(
-                "Connection to %s API was lost. Reconnecting in %i seconds",
-                self._device_type,
-                reconnect_seconds,
-            )
-
-            async def try_connect(retries):
-                try:
-                    await self._controller.connect()
-                    _LOGGER.info("Reconnected to %s API", self._device_type)
-                except IHConnectionError:
-                    if retries < MAX_RETRIES:
-                        wait_time = min(2**retries, MAX_WAIT_TIME)
-                        _LOGGER.info(
-                            "Failed to reconnect to %s API. Retrying in %i seconds",
-                            self._device_type,
-                            wait_time,
-                        )
-                        async_call_later(self.hass, wait_time, try_connect(retries + 1))
-                    else:
-                        _LOGGER.error(
-                            "Failed to reconnect to %s API after %i retries. Giving up",
-                            self._device_type,
-                            MAX_RETRIES,
-                        )
-
-                async_call_later(self.hass, reconnect_seconds, try_connect(0))
-
-        if self._controller.is_connected and not self._connected:
-            # Connection has been restored
+            _LOGGER.info("Connection to %s API was lost", self._device_type)
+        elif self._controller and self._controller.is_connected and not self._connected:
             self._connected = True
             _LOGGER.debug("Connection to %s API was restored", self._device_type)
 

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -42,31 +42,14 @@ MAP_IH_TO_PRESET_MODE = {
 }
 MAP_PRESET_MODE_TO_IH = {v: k for k, v in MAP_IH_TO_PRESET_MODE.items()}
 
-MAP_SWING_TO_IH = {
+_VANE_POSITIONS = {
     SWING_OFF: "auto/stop",
     "Swing": "swing",
-    "Position1": "manual1",
-    "Position2": "manual2", 
-    "Position3": "manual3",
-    "Position4": "manual4",
-    "Position5": "manual5",
-    "Position6": "manual6",
-    "Position7": "manual7",
-    "Position8": "manual8",
-    "Position9": "manual9",
+    **{f"Position{n}": f"manual{n}" for n in range(1, 10)},
 }
-MAP_IH_TO_SWING = {v: k for k, v in MAP_SWING_TO_IH.items()}
-
-MAP_HORIZONTAL_SWING_TO_IH = {
-    SWING_OFF: "auto/stop",
-    "Swing": "swing",
-    "Position1": "manual1",
-    "Position2": "manual2", 
-    "Position3": "manual3",
-    "Position4": "manual4",
-    "Position5": "manual5"
-}
-MAP_IH_TO_HORIZONTAL_SWING = {v: k for k, v in MAP_HORIZONTAL_SWING_TO_IH.items()}
+MAP_SWING_TO_IH = _VANE_POSITIONS
+MAP_HORIZONTAL_SWING_TO_IH = _VANE_POSITIONS
+MAP_IH_TO_SWING = {v: k for k, v in _VANE_POSITIONS.items()}
 
 MAP_STATE_ICONS = {
     HVACMode.COOL: "mdi:snowflake",
@@ -75,6 +58,23 @@ MAP_STATE_ICONS = {
     HVACMode.HEAT: "mdi:white-balance-sunny",
     HVACMode.HEAT_COOL: "mdi:cached",
 }
+
+
+def _swing_names_from_controller_list(ih_positions: list[str] | None) -> list[str]:
+    """Translate the controller's IH-name swing positions into HA names.
+
+    Unknown IH positions are logged at warning level and skipped.
+    """
+    if not ih_positions:
+        return []
+    names: list[str] = []
+    for ih in ih_positions:
+        ha = MAP_IH_TO_SWING.get(ih)
+        if ha is None:
+            _LOGGER.warning("Unexpected swingmode reported by device: %s", ih)
+            continue
+        names.append(ha)
+    return names
 
 async def async_setup_entry(
     hass: core.HomeAssistant,
@@ -141,46 +141,18 @@ class IntesisAC(ClimateEntity):
         if controller.has_setpoint_control(ih_device_id):
             self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
-        # Setup swing lists
-        if controller.has_vertical_swing(ih_device_id):
-            if hasattr(controller, "get_vertical_swing_list"):
-                if swingmodes := controller.get_vertical_swing_list(ih_device_id):
-                    swingmode_list = []
-                    for swingmode in swingmodes:
-                        if swingmode in MAP_IH_TO_SWING:
-                            swingmode_list.append(MAP_IH_TO_SWING[swingmode])
-                        else:
-                            _LOGGER.warning("Unexpected swingmode: %s", swingmode)
-                    self._swing_list.extend(swingmode_list)
-            else:
-                self._swing_list.extend([
-                    "Swing",
-                    "Position1",
-                    "Position2",
-                    "Position3", 
-                    "Position4"
-                ])
-        if controller.has_horizontal_swing(ih_device_id):
-            if hasattr(controller, "get_horizontal_swing_list"):
-                if swingmodes := controller.get_horizontal_swing_list(ih_device_id):
-                    swingmode_list = []
-                    for swingmode in swingmodes:
-                        if swingmode in MAP_IH_TO_SWING:
-                            swingmode_list.append(MAP_IH_TO_HORIZONTAL_SWING[swingmode])
-                        else:
-                            _LOGGER.warning("Unexpected swingmode: %s", swingmode)
-                    self._swing_horizontal_list.extend(swingmode_list)
-            else:
-                self._swing_list.extend([
-                    "Swing",
-                    "Position1",
-                    "Position2",
-                    "Position3", 
-                    "Position4"
-                ])
-        if len(self._swing_list) > 0:
+        # Setup swing lists. Positions advertised by the device are
+        # translated to user-facing names via MAP_IH_TO_SWING; anything
+        # not in the map is logged and skipped.
+        self._swing_list = _swing_names_from_controller_list(
+            controller.get_vertical_swing_list(ih_device_id)
+        )
+        self._swing_horizontal_list = _swing_names_from_controller_list(
+            controller.get_horizontal_swing_list(ih_device_id)
+        )
+        if self._swing_list:
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
-        if len(self._swing_horizontal_list) > 0:
+        if self._swing_horizontal_list:
             self._attr_supported_features |= ClimateEntityFeature.SWING_HORIZONTAL_MODE
 
         # Setup fan speeds
@@ -439,27 +411,17 @@ class IntesisAC(ClimateEntity):
 
     @property
     def swing_mode(self):
+        """Return the current vertical vane position as an HA-facing name."""
         if self._vvane is None:
             return None
-        swing = MAP_IH_TO_SWING.get(self._vvane)
-        if swing is None:
-            return None
-        try:
-            return swing
-        except ValueError:
-            return None
-    
+        return MAP_IH_TO_SWING.get(self._vvane)
+
     @property
     def swing_horizontal_mode(self):
-        if self._vvane is None:
+        """Return the current horizontal vane position as an HA-facing name."""
+        if self._hvane is None:
             return None
-        swing = MAP_IH_TO_SWING.get(self._hvane)
-        if swing is None:
-            return None
-        try:
-            return swing
-        except ValueError:
-            return None
+        return MAP_IH_TO_SWING.get(self._hvane)
 
     @property
     def fan_modes(self):

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -232,15 +232,30 @@ class IntesisAC(ClimateEntity):
         """Return the current preset mode."""
         return self._preset
     
+    async def _expect_ack(self, success: bool, description: str) -> None:
+        """Raise HomeAssistantError when a controller SET returns False.
+
+        The library's set_* methods return True when the cloud
+        acknowledges the command and False on timeout or invalid input.
+        Surface that as a service-call error so the user sees a
+        notification instead of a silently-dropped change.
+        """
+        if not success:
+            raise HomeAssistantError(
+                f"IntesisHome did not acknowledge {description}"
+            )
+
     async def async_turn_on(self) -> None:
         """Turn device on."""
+        ok = await self._controller.set_power_on(self._device_id)
+        await self._expect_ack(ok, "power on")
         self._power = True
-        await self._controller.set_power_on(self._device_id)
 
     async def async_turn_off(self) -> None:
         """Turn device off."""
+        ok = await self._controller.set_power_off(self._device_id)
+        await self._expect_ack(ok, "power off")
         self._power = False
-        await self._controller.set_power_off(self._device_id)
 
     async def async_toggle(self) -> None:
         """Toggle device status."""
@@ -256,7 +271,8 @@ class IntesisAC(ClimateEntity):
 
         if temperature := kwargs.get(ATTR_TEMPERATURE):
             _LOGGER.debug("Setting %s to %s degrees", self._device_type, temperature)
-            await self._controller.set_temperature(self._device_id, temperature)
+            ok = await self._controller.set_temperature(self._device_id, temperature)
+            await self._expect_ack(ok, f"temperature {temperature}")
             self._target_temp = temperature
 
         # Write updated temperature to HA state to avoid flapping (API confirmation is slow)
@@ -266,21 +282,28 @@ class IntesisAC(ClimateEntity):
         """Set operation mode."""
         _LOGGER.debug("Setting %s to %s mode", self._device_type, hvac_mode)
         if hvac_mode == HVACMode.OFF:
+            ok = await self._controller.set_power_off(self._device_id)
+            await self._expect_ack(ok, "power off")
             self._power = False
-            await self._controller.set_power_off(self._device_id)
             # Write changes to HA, API can be slow to push changes
             self.async_write_ha_state()
             return
 
         # First check device is turned on
         if not self._controller.is_on(self._device_id):
+            ok = await self._controller.set_power_on(self._device_id)
+            await self._expect_ack(ok, "power on")
             self._power = True
-            await self._controller.set_power_on(self._device_id)
 
         # Set the mode
-        await self._controller.set_mode(self._device_id, MAP_HVAC_MODE_TO_IH[hvac_mode])
+        ok = await self._controller.set_mode(
+            self._device_id, MAP_HVAC_MODE_TO_IH[hvac_mode]
+        )
+        await self._expect_ack(ok, f"HVAC mode {hvac_mode}")
 
-        # Send the temperature again in case changing modes has changed it
+        # Send the temperature again in case changing modes has changed it.
+        # Best-effort; a failure to re-apply isn't worth a user-facing
+        # error since the explicit hvac-mode change already landed.
         if self._target_temp:
             await self._controller.set_temperature(self._device_id, self._target_temp)
 
@@ -290,7 +313,8 @@ class IntesisAC(ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode):
         """Set fan mode (from quiet, low, medium, high, auto)."""
-        await self._controller.set_fan_speed(self._device_id, fan_mode)
+        ok = await self._controller.set_fan_speed(self._device_id, fan_mode)
+        await self._expect_ack(ok, f"fan mode {fan_mode!r}")
 
         # Updates can take longer than 2 seconds, so update locally
         self._fan_speed = fan_mode
@@ -299,21 +323,24 @@ class IntesisAC(ClimateEntity):
     async def async_set_preset_mode(self, preset_mode):
         """Set preset mode."""
         ih_preset_mode = MAP_PRESET_MODE_TO_IH.get(preset_mode)
-        await self._controller.set_preset_mode(self._device_id, ih_preset_mode)
+        ok = await self._controller.set_preset_mode(self._device_id, ih_preset_mode)
+        await self._expect_ack(ok, f"preset mode {preset_mode!r}")
 
     async def async_set_swing_mode(self, swing_mode):
         """Set the vertical vane."""
         if swingmode := MAP_SWING_TO_IH.get(swing_mode):
-            await self._controller.set_vertical_vane(
+            ok = await self._controller.set_vertical_vane(
                 self._device_id, swingmode
             )
+            await self._expect_ack(ok, f"vertical vane {swing_mode!r}")
 
     async def async_set_swing_horizontal_mode(self, swing_mode):
         """Set the horizontal vane."""
-        if swingmode := MAP_HORIZONTAL_SWING_TO_IH.get(swing_mode):
-            await self._controller.set_horizontal_vane(
+        if swingmode := MAP_SWING_TO_IH.get(swing_mode):
+            ok = await self._controller.set_horizontal_vane(
                 self._device_id, swingmode
             )
+            await self._expect_ack(ok, f"horizontal vane {swing_mode!r}")
 
     async def async_update(self):
         """Copy values from controller dictionary to climate device."""

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -232,7 +232,7 @@ class IntesisAC(ClimateEntity):
         """Return the current preset mode."""
         return self._preset
     
-    async def _expect_ack(self, success: bool, description: str) -> None:
+    def _expect_ack(self, success: bool, description: str) -> None:
         """Raise HomeAssistantError when a controller SET returns False.
 
         The library's set_* methods return True when the cloud
@@ -248,13 +248,13 @@ class IntesisAC(ClimateEntity):
     async def async_turn_on(self) -> None:
         """Turn device on."""
         ok = await self._controller.set_power_on(self._device_id)
-        await self._expect_ack(ok, "power on")
+        self._expect_ack(ok, "power on")
         self._power = True
 
     async def async_turn_off(self) -> None:
         """Turn device off."""
         ok = await self._controller.set_power_off(self._device_id)
-        await self._expect_ack(ok, "power off")
+        self._expect_ack(ok, "power off")
         self._power = False
 
     async def async_toggle(self) -> None:
@@ -272,7 +272,7 @@ class IntesisAC(ClimateEntity):
         if temperature := kwargs.get(ATTR_TEMPERATURE):
             _LOGGER.debug("Setting %s to %s degrees", self._device_type, temperature)
             ok = await self._controller.set_temperature(self._device_id, temperature)
-            await self._expect_ack(ok, f"temperature {temperature}")
+            self._expect_ack(ok, f"temperature {temperature}")
             self._target_temp = temperature
 
         # Write updated temperature to HA state to avoid flapping (API confirmation is slow)
@@ -283,7 +283,7 @@ class IntesisAC(ClimateEntity):
         _LOGGER.debug("Setting %s to %s mode", self._device_type, hvac_mode)
         if hvac_mode == HVACMode.OFF:
             ok = await self._controller.set_power_off(self._device_id)
-            await self._expect_ack(ok, "power off")
+            self._expect_ack(ok, "power off")
             self._power = False
             # Write changes to HA, API can be slow to push changes
             self.async_write_ha_state()
@@ -292,14 +292,14 @@ class IntesisAC(ClimateEntity):
         # First check device is turned on
         if not self._controller.is_on(self._device_id):
             ok = await self._controller.set_power_on(self._device_id)
-            await self._expect_ack(ok, "power on")
+            self._expect_ack(ok, "power on")
             self._power = True
 
         # Set the mode
         ok = await self._controller.set_mode(
             self._device_id, MAP_HVAC_MODE_TO_IH[hvac_mode]
         )
-        await self._expect_ack(ok, f"HVAC mode {hvac_mode}")
+        self._expect_ack(ok, f"HVAC mode {hvac_mode}")
 
         # Send the temperature again in case changing modes has changed it.
         # Best-effort; a failure to re-apply isn't worth a user-facing
@@ -314,7 +314,7 @@ class IntesisAC(ClimateEntity):
     async def async_set_fan_mode(self, fan_mode):
         """Set fan mode (from quiet, low, medium, high, auto)."""
         ok = await self._controller.set_fan_speed(self._device_id, fan_mode)
-        await self._expect_ack(ok, f"fan mode {fan_mode!r}")
+        self._expect_ack(ok, f"fan mode {fan_mode!r}")
 
         # Updates can take longer than 2 seconds, so update locally
         self._fan_speed = fan_mode
@@ -324,7 +324,7 @@ class IntesisAC(ClimateEntity):
         """Set preset mode."""
         ih_preset_mode = MAP_PRESET_MODE_TO_IH.get(preset_mode)
         ok = await self._controller.set_preset_mode(self._device_id, ih_preset_mode)
-        await self._expect_ack(ok, f"preset mode {preset_mode!r}")
+        self._expect_ack(ok, f"preset mode {preset_mode!r}")
 
     async def async_set_swing_mode(self, swing_mode):
         """Set the vertical vane."""
@@ -332,7 +332,7 @@ class IntesisAC(ClimateEntity):
             ok = await self._controller.set_vertical_vane(
                 self._device_id, swingmode
             )
-            await self._expect_ack(ok, f"vertical vane {swing_mode!r}")
+            self._expect_ack(ok, f"vertical vane {swing_mode!r}")
 
     async def async_set_swing_horizontal_mode(self, swing_mode):
         """Set the horizontal vane."""
@@ -340,7 +340,7 @@ class IntesisAC(ClimateEntity):
             ok = await self._controller.set_horizontal_vane(
                 self._device_id, swingmode
             )
-            await self._expect_ack(ok, f"horizontal vane {swing_mode!r}")
+            self._expect_ack(ok, f"horizontal vane {swing_mode!r}")
 
     async def async_update(self):
         """Copy values from controller dictionary to climate device."""
@@ -389,10 +389,16 @@ class IntesisAC(ClimateEntity):
                 self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
 
     async def async_will_remove_from_hass(self):
-        """Shutdown the controller when the device is being removed."""
+        """Detach from the shared controller's update stream.
+
+        The controller's lifecycle is owned by the integration
+        (constructed in __init__.async_setup_entry, stopped in
+        async_unload_entry) so this entity must NOT call stop() here.
+        Doing so would tear down the shared controller when a single
+        entity is removed or disabled, and would also race the
+        integration-level stop on entry unload.
+        """
         self._controller.remove_update_callback(self.async_update_callback)
-        await self._controller.stop()
-        self._controller = None
 
     @property
     def icon(self):

--- a/custom_components/intesishome/config_flow.py
+++ b/custom_components/intesishome/config_flow.py
@@ -21,7 +21,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import DOMAIN
@@ -38,7 +38,7 @@ class IntesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._data = {}
 
-    async def async_step_user(self, user_input=None) -> FlowResult:
+    async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle the initial device type selection step."""
         # unique_id = user_input["unique_id"]
         # await self.async_set_unique_id(unique_id)
@@ -68,7 +68,7 @@ class IntesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=device_type_schema, errors=errors
         )
 
-    async def async_step_details(self, user_input=None) -> FlowResult:
+    async def async_step_details(self, user_input=None) -> ConfigFlowResult:
         """Handle the device connection step."""
         device_type = self._data.get(CONF_DEVICE)
         errors: dict[str, str] = {}
@@ -170,7 +170,7 @@ class IntesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="details", data_schema=cloud_schema, errors=errors
         )
 
-    async def async_step_import(self, import_data) -> FlowResult:
+    async def async_step_import(self, import_data) -> ConfigFlowResult:
         """Handle configuration by yaml file."""
         return await self.async_step_user(import_data)
 

--- a/custom_components/intesishome/config_flow.py
+++ b/custom_components/intesishome/config_flow.py
@@ -120,45 +120,42 @@ class IntesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     websession=async_get_clientsession(self.hass),
                 )
 
-        # Try to attempt a connection
-        try:
-            if controller and isinstance(controller, IntesisBox):
-                await controller.connect()
-            elif controller:
-                await controller.poll_status()
-        except IHAuthenticationError:
-            errors["base"] = "invalid_auth"
-            controller = None
-        except IHConnectionError:
-            errors["base"] = "cannot_connect"
-            controller = None
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-            controller = None
-
+        # Try to attempt a connection. The controller is only used here to
+        # verify credentials and discover the device identity - the
+        # integration's async_setup_entry constructs a fresh one. Always
+        # clean it up via try/finally so an extra TCP / HTTP session
+        # doesn't leak after the flow finishes.
         if controller:
-            if len(controller.get_devices()) == 0:
-                errors["base"] = "no_devices"
+            try:
+                if isinstance(controller, IntesisBox):
+                    await controller.connect()
+                else:
+                    await controller.poll_status()
 
-            if "base" not in errors:
-                unique_id = (
-                    f"{controller.device_type}_{controller.controller_id}".lower()
-                )
-                name = f"{controller.device_type} {controller.name}"
+                if len(controller.get_devices()) == 0:
+                    errors["base"] = "no_devices"
+                else:
+                    unique_id = (
+                        f"{controller.device_type}_{controller.controller_id}".lower()
+                    )
+                    name = f"{controller.device_type} {controller.name}"
 
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
 
-                # Pass the controller through to the platform setup
-                self.hass.data.setdefault(DOMAIN, {})
-                self.hass.data[DOMAIN].setdefault("controller", {})
-                self.hass.data[DOMAIN]["controller"][unique_id] = controller
-
-                return self.async_create_entry(
-                    title=name,
-                    data=user_input,
-                )
+                    return self.async_create_entry(
+                        title=name,
+                        data=user_input,
+                    )
+            except IHAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except IHConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            finally:
+                await controller.stop()
 
         # Show the correct configuration schema
         if device_type == DEVICE_INTESISBOX:

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==2.0.0"],
+  "requirements": ["pyintesishome==2.0.1"],
   "version": "1.1.1"
 }

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==1.8.5"],
+  "requirements": ["pyintesishome==2.0.0"],
   "version": "1.1.1"
 }


### PR DESCRIPTION
# Lifecycle refactor + merge swing-modes PR #27 + error surfacing

## Why

Companion to the now-merged `pyintesishome` 2.0.0 release, which adds
auto-reconnect, `set_ack` correlation, and bool-returning `set_*`
methods. This PR is the integration-side surface of those library
changes, plus a merge of @srkoster's swing-modes work from #27.

The PR grew from debugging a chronic "the IntesisHome integration goes
unavailable until I reload it" problem. The library 2.0.0 release fixes
the underlying connection-lifecycle issue; this PR consumes the new
library APIs, brings in srkoster's superior swing-mode design, and
surfaces SET failures to the user.

Closes #27.

## Commit-by-commit

### 1. `refactor: integration-level controller lifecycle`

Three related lifecycle changes folded together:

- Controller construction moves from `climate.async_setup_entry` to the
  integration-level `async_setup_entry`. The controller lives on
  `hass.data[DOMAIN][entry_id]["controller"]`. `async_unload_entry`
  stops it cleanly.
- The in-entity `try_connect` retry is removed. The library's
  auto-reconnect now handles this and the in-entity loop races it.
- `controller.connect()` runs inside `async_setup_entry` rather than
  in `async_added_to_hass`. Eliminates the duplicate `poll_status()`
  the entity-level path used to trigger and the "Setup of climate
  platform taking over 10 seconds" warning on cold start.
  `ConfigEntryAuthFailed` / `ConfigEntryNotReady` cover what
  `PlatformNotReady` used to.

### 2. `Merge srkoster's swing modes implementation (PR #27)`

A literal merge of @srkoster's `ft_swing_modes` branch (PR #27 against
this repo), preserving authorship on the two underlying commits. The
design exposes each discrete vane position directly on the climate
entity's `swing_modes` / `swing_horizontal_modes` lists, populated from
the controller's `get_vertical_swing_list` / `get_horizontal_swing_list`
helpers added in pyintesishome 2.0.0.

### 3. `Bump pyintesishome requirement to 2.0.0`

The merged work depends on the new helpers and bool-returning setters
that ship in 2.0.0. Without the bump, surfaced failures would always
fire (every `set_*` returns `None`, which is falsy) and the
swing-mode population path would crash. Integration version is left
for the maintainer to bump on merge.

### 4. `Clean up swing-mode handling from merged PR #27`

Fixes a handful of rough edges that surfaced in srkoster's contribution
once it was merged in:

- `swing_horizontal_mode` was checking `self._vvane` (typo); now checks
  `self._hvane`.
- `swing_horizontal_mode` was using the vertical IH→HA map; collapsed
  both directions into a single `_VANE_POSITIONS` dict with manual1–9
  so the horizontal-axis 9-position case works.
- The horizontal `hasattr` fallback was appending to `self._swing_list`
  instead of `self._swing_horizontal_list`.
- Dropped the whole `hasattr(controller, "get_vertical_swing_list")`
  fallback now that the manifest pins pyintesishome ≥ 2.0.0.
- Dead `try/except ValueError` around plain returns removed.
- Trailing whitespace stripped from the position name literals.
- IH-list → HA-name translation extracted into a module-level helper
  so the per-axis call sites are one line each.

### 5. `Surface unacknowledged SETs to the user via HomeAssistantError`

The library's `set_*` methods now return `False` on timeout. Every
climate service handler (`turn_on`, `turn_off`, `set_temperature`,
`set_hvac_mode`, `set_fan_mode`, `set_preset_mode`, `set_swing_mode`,
`set_swing_horizontal_mode`) checks the return and raises
`HomeAssistantError` on `False`, so the user sees a service-call error
instead of a silent rollback. A short `_expect_ack` helper keeps each
call site to two lines. The trailing re-application of `target_temp` in
`async_set_hvac_mode` is treated as best-effort and doesn't raise.

### 6. `chore: optional _vendor/ bootstrap for in-progress library iteration`

Opt-in by file presence: if `custom_components/intesishome/_vendor/pyintesishome/`
exists, the integration loads from there in preference to the
manifest-pinned library. No-op when absent. **Purely a dev
convenience** for testing library changes against a live HA install
without rebuilding HA's venv. Happy to drop this commit before merging.

## Testing

- Running on my HA install for a couple of weeks against an Intesis WMP
  (modelId 550, IntesisHome cloud). Reconnect storms are gone, swing
  positions show up correctly in the dropdown, and surfaced failures
  appear as service-call errors when the cloud doesn't ACK.

## Open questions

1. **`_vendor/` bootstrap** is dev-only and removable without affecting
   any other commit. Let me know which way you'd like it.
2. The integration version field is left at the current value; happy to
   bump as part of this PR or leave for the maintainer.
