### PR TITLE
fix: bump actions/checkout to v4 and opt into Node 24 runners

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   validate:
     runs-on: "ubuntu-latest"
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: HACS validation
         uses: "hacs/action@main"


### PR DESCRIPTION
The CI workflows have two issues:

1. `actions/checkout@v3` is fully deprecated (Node 16) — bumped to `@v4`
2. Actions declare Node 20 internally which will produce deprecation warnings and break when Node 20 is removed from runners later in 2026

Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to both workflow jobs to opt into Node 24 ahead of the forced migration on June 2nd, 2026.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/