### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,138 @@
-# Home Assistant IntesisHome integration (with config flow)
-Development fork of the IntesisHome integration for Home Assistant
+# IntesisHome for Home Assistant
 
-*This project is seeking a new maintainer, I haven't owned an Intesis device for many years, and no longer have the time to contribute to this project. Please get in touch if you are interested in taking this over. I've spent many mornings at the local coffee shop working on this project, if it has been useful to you please consider buying me a coffee with the link below, thank you!*
+A Home Assistant integration for Intesis AC controllers, supporting cloud control (IntesisHome, anywAir, airconwithme) and local control (IntesisBox, IntesisHome Local HTTP).
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/jnimmo)
 
+---
 
-This custom integration is a fork of the core integration for IntesisHome which adds experimental support for local control over HTTP for selected devices, local control over WMP (IntesisBox), and cloud control for IntesisHome, anywAir, airconwithme.
-This is ready to integrate back into Home Assistant Core however it needs unit tests written for Config Flow for that to be able to happen, which I haven't got the time to invest in at this stage.
+## Installation
+
+### HACS (recommended)
+
+1. Open HACS in Home Assistant and go to **Integrations**
+2. Click the three-dot menu → **Custom repositories**
+3. Add `https://github.com/jnimmo/hass-intesishome` with category **Integration**
+4. Search for **IntesisHome** and install it
+5. Restart Home Assistant
+
+### Manual
+
+Download the `custom_components/intesishome` directory into your Home Assistant `custom_components` folder, then restart.
+
+---
 
 ## Configuration
-1. Add this custom repository to HACS, or manually download the files into your custom_components directory
-2. Restart Home Assistant
-3. [![Start IntesisHome configuration in Home Assistant](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=intesishome) or navigate to integrations and add the IntesisHome integration through the user interface 
-5. Select the device type
-6. Provide any additional required details (username, password, IP address) for your device
+
+1. Restart Home Assistant after installation
+2. [![Add IntesisHome integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start?domain=intesishome) or go to **Settings → Devices & Services → Add Integration** and search for **IntesisHome**
+3. Select your device type (see [Device types](#device-types) below)
+4. Enter the required credentials or IP address for your device type
+5. Your AC devices will appear as climate entities
+
+---
+
+## Device types
+
+| Device type       | Protocol     | Required details                              |
+| ----------------- | ------------ | --------------------------------------------- |
+| IntesisHome       | Cloud        | Username and password                         |
+| anywAir           | Cloud        | Username and password                         |
+| airconwithme      | Cloud        | Username and password                         |
+| IntesisBox        | Local (WMP)  | IP address or hostname                        |
+| IntesisHome Local | Local (HTTP) | IP address or hostname, username and password |
+
+---
+
+## Supported functionality
+
+Features supported depend on the physical device. The integration detects capabilities at setup time and only exposes features your device supports.
+
+| Feature             | Notes                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| HVAC modes          | Heat, cool, heat/cool (auto), dry, fan only, off                                                              |
+| Target temperature  | Whole or half-degree steps depending on device                                                                |
+| Fan modes           | Auto, quiet, low, medium, high (device-dependent)                                                             |
+| Vertical swing      | Off, swing, or up to 9 discrete vane positions (device-dependent)                                             |
+| Horizontal swing    | Off, swing, or up to 9 discrete vane positions (device-dependent), controlled independently of vertical swing |
+| Preset modes        | Eco, comfort, boost (powerful)                                                                                |
+| Turn on / turn off  | Independent on/off without changing mode                                                                      |
+| Outdoor temperature | Exposed as `outdoor_temp` state attribute where supported                                                     |
+| Power consumption   | `power_consumption_heat_kw` and `power_consumption_cool_kw` state attributes where supported                  |
+
+If a command is not acknowledged by the device or cloud within 5 seconds, Home Assistant will display a visible error notification rather than silently dropping the change.
+
+---
 
 ## Cloud control
-Control of IntesisHome, anywAir, airconwithme devices generally is through a persistent connection to the Intesis cloud.
-This requires outgoing HTTPS access to connect to the API, then control moves to a TCP port specified by the API. 
+
+IntesisHome, anywAir, and airconwithme devices connect via a persistent TCP connection established through the Intesis cloud API. This requires outgoing HTTPS access to reach the API endpoint; control then moves to a TCP port returned by the API.
+
+If the connection drops, the integration reconnects automatically. Reconnect behaviour (backoff timing, retries) is handled by the pyintesishome library.
+
+---
 
 ## Local control
 
-### HTTP (intesishome_local)
-This experimental feature allows local control over HTTP for devices which expose an HTTP web server on port 80 (http://ip/api.cgi)
-| Device                  | HTTP - intesishome_local | 
-| ----------------------- |:-------------------------| 
-| DK-RC-WIFI-1B           | :white_check_mark:       | 
-| FJ-AC-WIFI-1B           | :white_check_mark:       |
-| MH-AC-WIFI-1            | :white_check_mark:       |
-| IS-ASX-WIFI-1           | :x:                      |
+### HTTP — IntesisHome Local
 
-### WMP (Intesisbox)
-There are two forks for Intesisbox support. Intesisbox support was added to the pyintesishome library which this integration uses, however the original https://github.com/jnimmo/hass-intesisbox integration is likely to be better maintaned for the time being. 
+Experimental local control for devices that expose an HTTP API on port 80 (`http://<ip>/api.cgi`). Requires IP address, username, and password.
+
+| Device        | Supported |
+| ------------- | --------- |
+| DK-RC-WIFI-1B | Yes       |
+| FJ-AC-WIFI-1B | Yes       |
+| MH-AC-WIFI-1  | Yes       |
+| IS-ASX-WIFI-1 | No        |
+
+### WMP — IntesisBox
+
+IntesisBox devices use the WMP protocol over a local TCP connection. Only an IP address or hostname is required — no cloud account needed.
+
+For dedicated IntesisBox support, the standalone [hass-intesisbox](https://github.com/jnimmo/hass-intesisbox) integration may be better maintained.
+
+---
+
+## Troubleshooting
+
+**Invalid username or password** — verify your credentials in the Intesis mobile app. Cloud accounts are per-service: an IntesisHome account will not work for anywAir.
+
+**No devices found** — ensure at least one device is registered and visible in the Intesis mobile app before setting up the integration.
+
+**Unavailable after connection drop** — the integration reconnects automatically. If a device stays unavailable, check that your Home Assistant instance has outgoing internet access (cloud) or that the device IP has not changed (local).
+
+**Changing mode resets temperature** — some devices reset the setpoint when the HVAC mode changes. The integration re-sends the current target temperature after a mode change to compensate.
+
+## Debug logging
+
+To capture detailed logs for troubleshooting, add the following to your `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.intesishome: debug
+    pyintesishome: debug
+```
+
+Restart Home Assistant, reproduce the issue, then download the logs from **Settings → System → Logs**.
+
+## Raising an issue
+
+Before opening an issue, check the [existing issues](https://github.com/jnimmo/hass-intesishome/issues) to see if it has already been reported.
+
+When opening a new issue, please include:
+
+- Your Home Assistant version
+- The device type you are using (IntesisHome, anywAir, IntesisBox, etc.)
+- Debug logs covering the period when the problem occurred (see above)
+- A description of what you expected to happen and what actually happened
+
+---
+
+## About
+
+This integration extends the [IntesisHome core integration](https://www.home-assistant.io/integrations/intesishome) with config flow support, local HTTP control, and additional climate features.
+
+_This project is seeking a new maintainer — I no longer own an Intesis device and have limited time to contribute. Please contact me if you are interested in taking it over._

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
   "requirements": ["pyintesishome==2.0.1"],
-  "version": "1.1.1"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Summary

Bump version to 2.0.0, aligning the major version with the pyintesishome 2.0 dependency. Includes several feature and reliability improvements contributed over the past few months.

## Changes

**Swing vane positions** — vertical and horizontal swing now expose discrete vane positions (Position1–9) where the device supports them, rather than just on/off/swing. (@srkoster, #27)

**Independent horizontal swing** — horizontal swing is now controlled as a separate axis from vertical swing, allowing both to be set independently. (@srkoster, #24)

**Failed command feedback** — SET commands that are not acknowledged by the device or cloud within 5 seconds now surface as a visible error notification in the HA frontend, rather than being silently dropped. (@peter-dolkens, #41)

**Turn on / turn off** — the climate entity now supports `turn_on` and `turn_off` independently of mode changes, aligning with the HA 2024.1 `ClimateEntityFeature` requirements. (@srkoster, #22)

**Integration-level controller lifecycle** — the controller is now constructed and torn down at the integration level rather than per-entity, so all platforms share one TCP session and unload is clean. (@peter-dolkens, #41)

**Reconnect handling moved to library** — integration-side retry logic removed; pyintesishome 2.0 handles reconnect with its own backoff. (@peter-dolkens, #41)

**HA 2026.x compatibility** — `FlowResult` replaced with `ConfigFlowResult` to avoid deprecation warnings on recent HA versions. (@peter-dolkens, #41)

**pyintesishome bumped to 2.0.1** — required for the above changes.

**CI: actions/checkout v4 + Node 24 runners** (@kesawi, #42)

**Updated README** — full feature documentation, installation steps, debug logging instructions, and issue reporting guidance.