### PR TITLE
feat: add device registry info

### DIFF
--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN
@@ -494,3 +495,16 @@ class IntesisAC(ClimateEntity):
         if self._power and self.hvac_mode not in [HVACMode.FAN_ONLY, HVACMode.OFF]:
             return self._target_temp
         return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        model = self._controller.get_model(self._device_id) if hasattr(self._controller, "get_model") else None
+        sw_version = self._controller.get_fw_version(self._device_id) if hasattr(self._controller, "get_fw_version") else None
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._controller.controller_id, self._device_id)},
+            name=self._device_name,
+            manufacturer=self._device_type.capitalize(),
+            model=model,
+            sw_version=sw_version,
+        )


### PR DESCRIPTION
Closes #28.

Adds a `device_info` property to the climate entity so each AC unit appears in the HA device registry with its name, manufacturer, model, and firmware version (where the library supports it).

Originally authored by @srkoster in #28. Manually applied to the current codebase to resolve conflicts with the lifecycle refactor from #41, and updated to import `DeviceInfo` from `homeassistant.helpers.device_registry` (the canonical location in current HA versions).