### PR TITLE
Add device registry, sensor and binary_sensor platforms (supersedes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,25 @@ Features supported depend on the physical device. The integration detects capabi
 | Horizontal swing    | Off, swing, or up to 9 discrete vane positions (device-dependent), controlled independently of vertical swing |
 | Preset modes        | Eco, comfort, boost (powerful)                                                                                |
 | Turn on / turn off  | Independent on/off without changing mode                                                                      |
-| Outdoor temperature | Exposed as `outdoor_temp` state attribute where supported                                                     |
+| Outdoor temperature | Exposed as a sensor entity, and as the `outdoor_temp` state attribute for backwards compatibility             |
 | Power consumption   | `power_consumption_heat_kw` and `power_consumption_cool_kw` state attributes where supported                  |
 
 If a command is not acknowledged by the device or cloud within 5 seconds, Home Assistant will display a visible error notification rather than silently dropping the change.
+
+### Sensors
+
+Each AC unit appears in Home Assistant as a **device**, grouping the climate entity together with the sensors below. The device page shows the model, firmware version and serial number, and links to the gateway's own web interface.
+
+| Entity                     | Type          | Notes                                                                       |
+| -------------------------- | ------------- | --------------------------------------------------------------------------- |
+| Outdoor temperature        | sensor        | Full history and long-term statistics, unlike the state attribute            |
+| Run hours                  | sensor        | Total compressor/unit run time reported by the device (diagnostic)           |
+| Error code                 | sensor        | Raw vendor error code (diagnostic, disabled by default)                      |
+| Signal strength            | sensor        | WiFi RSSI (diagnostic, disabled by default)                                  |
+| Problem                    | binary_sensor | On when the device reports an alarm (diagnostic)                             |
+| Connectivity               | binary_sensor | Whether the integration currently has a live session (diagnostic)            |
+
+These entities are only created when your device actually reports the underlying value, so you will not see permanently-unavailable entities for features your hardware does not have. Which ones appear varies by model — for example, WiFi signal strength is currently only reported over the cloud connection.
 
 ---
 

--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -29,8 +29,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-DOMAIN = "intesishome"
-PLATFORMS = ["climate"]
+from .const import DOMAIN, PLATFORMS
+
+# DOMAIN is re-exported here because climate.py (and any out-of-tree fork)
+# imports it as `from . import DOMAIN`.
+__all__ = ["DOMAIN", "PLATFORMS"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/intesishome/binary_sensor.py
+++ b/custom_components/intesishome/binary_sensor.py
@@ -1,0 +1,110 @@
+"""Binary sensor platform for IntesisHome."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from pyintesishome import IntesisBase
+
+from homeassistant import config_entries, core
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import CONF_HOST, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import IntesisEntity, has_device_property
+
+# Sentinel for entities derived from controller state rather than from a
+# device datapoint, so they are always created.
+_NO_PROPERTY_REQUIRED = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class IntesisBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes an IntesisHome binary sensor."""
+
+    value_fn: Callable[[IntesisBase, str], bool | None]
+    required_property: str | None = _NO_PROPERTY_REQUIRED
+    # True for entities that must keep reporting while the session is down.
+    always_available: bool = False
+
+
+BINARY_SENSOR_TYPES: tuple[IntesisBinarySensorEntityDescription, ...] = (
+    IntesisBinarySensorEntityDescription(
+        key="problem",
+        translation_key="problem",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        required_property="alarm_status",
+        # alarm_status is a dedicated register that rests at 0. Deriving this
+        # from get_error() instead would report a permanent problem, because
+        # error code 0 maps to a truthy "H00: No abnormality detected".
+        value_fn=lambda controller, device_id: bool(
+            controller.get_device_property(device_id, "alarm_status")
+        ),
+    ),
+    IntesisBinarySensorEntityDescription(
+        key="connectivity",
+        translation_key="connectivity",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # A connectivity sensor that goes unavailable when the connection
+        # drops reports nothing at exactly the moment it is needed.
+        always_available=True,
+        value_fn=lambda controller, device_id: controller.is_connected,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create binary sensor entities."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    controller: IntesisBase = entry_data["controller"]
+    host: str | None = entry_data["config"].get(CONF_HOST)
+
+    async_add_entities(
+        IntesisBinarySensor(controller, device_id, ih_device, host, description)
+        for device_id, ih_device in (controller.get_devices() or {}).items()
+        for description in BINARY_SENSOR_TYPES
+        if description.required_property is _NO_PROPERTY_REQUIRED
+        or has_device_property(controller, device_id, description.required_property)
+    )
+
+
+class IntesisBinarySensor(IntesisEntity, BinarySensorEntity):
+    """A binary reading from an Intesis controller."""
+
+    entity_description: IntesisBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        controller: IntesisBase,
+        device_id: str,
+        ih_device: dict,
+        host: str | None,
+        description: IntesisBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(controller, device_id, ih_device, host)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}-{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the current state."""
+        return self.entity_description.value_fn(self._controller, self._device_id)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the reading can be trusted."""
+        if self.entity_description.always_available:
+            return True
+        return super().available

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -19,11 +19,10 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, CONF_HOST, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .entity import build_device_info
+from .entity import IntesisEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,18 +101,18 @@ async def async_setup_entry(
 
 
 # pylint: disable=too-many-instance-attributes, too-many-arguments, too-many-public-methods
-class IntesisAC(ClimateEntity):
+class IntesisAC(IntesisEntity, ClimateEntity):
     """Represents an Intesishome air conditioning device."""
 
     _enable_turn_on_off_backwards_compatibility = False
+    # The AC unit is the device's primary feature, so it carries the device's
+    # own name. This keeps friendly_name byte-identical to what it was before
+    # has_entity_name was adopted, so no existing install sees a rename.
+    _attr_name = None
 
     def __init__(self, ih_device_id, ih_device, controller, host=None) -> None:
         """Initialize the thermostat."""
-        self._controller: IntesisBase = controller
-        self._device_id: str = ih_device_id
-        self._ih_device: dict[str, dict[str, object]] = ih_device
-        self._device_name: str = ih_device.get("name")
-        self._device_type: str = controller.device_type
+        super().__init__(controller, ih_device_id, ih_device, host)
         self._host: str | None = host
         self._connected: bool = False
         self._setpoint_step: float = 1.0
@@ -184,16 +183,11 @@ class IntesisAC(ClimateEntity):
         """Subscribe to event updates.
 
         The controller is already connected by the time the entity is
-        added (see __init__.async_setup_entry) so this only needs to
+        added (see __init__.async_setup_entry) so the base class only needs to
         register the state-update callback.
         """
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
-        self._controller.add_update_callback(self.async_update_callback)
-
-    @property
-    def name(self):
-        """Return the name of the AC device."""
-        return self._device_name
+        await super().async_added_to_hass()
 
     @property
     def temperature_unit(self):
@@ -219,7 +213,13 @@ class IntesisAC(ClimateEntity):
 
     @property
     def unique_id(self):
-        """Return unique ID for this device."""
+        """Return unique ID for this device.
+
+        Deliberately the bare device_id, not a suffixed key like the sensor
+        entities use. This looks inconsistent but must not be "fixed":
+        changing it would orphan every existing user's climate entity, taking
+        its history and any automations referencing it with it.
+        """
         return self._device_id
 
     @property
@@ -393,18 +393,6 @@ class IntesisAC(ClimateEntity):
             if self._ih_device.get("climate_working_mode"):
                 self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
 
-    async def async_will_remove_from_hass(self):
-        """Detach from the shared controller's update stream.
-
-        The controller's lifecycle is owned by the integration
-        (constructed in __init__.async_setup_entry, stopped in
-        async_unload_entry) so this entity must NOT call stop() here.
-        Doing so would tear down the shared controller when a single
-        entity is removed or disabled, and would also race the
-        integration-level stop on entry unload.
-        """
-        self._controller.remove_update_callback(self.async_update_callback)
-
     @property
     def icon(self):
         """Return the icon for the current state."""
@@ -423,9 +411,7 @@ class IntesisAC(ClimateEntity):
             self._connected = True
             _LOGGER.debug("Connection to %s API was restored", self._device_type)
 
-        if not device_id or self._device_id == device_id:
-            # Update all devices if no device_id was specified
-            self.async_schedule_update_ha_state(True)
+        await super().async_update_callback(device_id)
 
     @property
     def min_temp(self):
@@ -436,11 +422,6 @@ class IntesisAC(ClimateEntity):
     def max_temp(self):
         """Return the maximum temperature for the current mode of operation."""
         return self._max_temp
-
-    @property
-    def should_poll(self):
-        """Poll for updates if pyIntesisHome doesn't have a socket open."""
-        return False
 
     @property
     def fan_mode(self):
@@ -504,9 +485,3 @@ class IntesisAC(ClimateEntity):
         # Return setpoint for all other modes, even when off
         return self._target_temp
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info shared with every other platform."""
-        return build_device_info(
-            self._controller, self._device_id, self._ih_device, self._host
-        )

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -17,12 +17,13 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import ATTR_TEMPERATURE, CONF_HOST, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN
+from .const import DOMAIN
+from .entity import build_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,11 +88,13 @@ async def async_setup_entry(
     The controller is constructed in __init__.async_setup_entry and stored
     on hass.data so every platform shares one TCP session.
     """
-    controller: IntesisBase = hass.data[DOMAIN][config_entry.entry_id]["controller"]
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    controller: IntesisBase = entry_data["controller"]
+    host: str | None = entry_data["config"].get(CONF_HOST)
     ih_devices = controller.get_devices() or {}
     async_add_entities(
         [
-            IntesisAC(ih_device_id, device, controller)
+            IntesisAC(ih_device_id, device, controller, host)
             for ih_device_id, device in ih_devices.items()
         ],
         update_before_add=True,
@@ -104,13 +107,14 @@ class IntesisAC(ClimateEntity):
 
     _enable_turn_on_off_backwards_compatibility = False
 
-    def __init__(self, ih_device_id, ih_device, controller) -> None:
+    def __init__(self, ih_device_id, ih_device, controller, host=None) -> None:
         """Initialize the thermostat."""
         self._controller: IntesisBase = controller
         self._device_id: str = ih_device_id
         self._ih_device: dict[str, dict[str, object]] = ih_device
         self._device_name: str = ih_device.get("name")
         self._device_type: str = controller.device_type
+        self._host: str | None = host
         self._connected: bool = False
         self._setpoint_step: float = 1.0
         self._current_temp: float = None
@@ -502,13 +506,7 @@ class IntesisAC(ClimateEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        model = self._controller.get_model(self._device_id) if hasattr(self._controller, "get_model") else None
-        sw_version = self._controller.get_fw_version(self._device_id) if hasattr(self._controller, "get_fw_version") else None
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._controller.controller_id, self._device_id)},
-            name=self._device_name,
-            manufacturer=self._device_type.capitalize(),
-            model=model,
-            sw_version=sw_version,
+        """Return device info shared with every other platform."""
+        return build_device_info(
+            self._controller, self._device_id, self._ih_device, self._host
         )

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN
@@ -495,6 +496,19 @@ class IntesisAC(ClimateEntity):
         # Don't show temperature for FAN_ONLY mode (no temperature control)
         if self.hvac_mode == HVACMode.FAN_ONLY:
             return None
-        
+
         # Return setpoint for all other modes, even when off
         return self._target_temp
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        model = self._controller.get_model(self._device_id) if hasattr(self._controller, "get_model") else None
+        sw_version = self._controller.get_fw_version(self._device_id) if hasattr(self._controller, "get_fw_version") else None
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._controller.controller_id, self._device_id)},
+            name=self._device_name,
+            manufacturer=self._device_type.capitalize(),
+            model=model,
+            sw_version=sw_version,
+        )

--- a/custom_components/intesishome/const.py
+++ b/custom_components/intesishome/const.py
@@ -1,0 +1,13 @@
+"""Constants for the IntesisHome integration."""
+from __future__ import annotations
+
+DOMAIN = "intesishome"
+
+PLATFORMS: list[str] = ["binary_sensor", "climate", "sensor"]
+
+# The device_type reported by the library ("intesishome", "intesishome_local",
+# "intesisbox", "airconwithme") describes the transport, not who made the
+# hardware. All of them are Intesis gateways.
+MANUFACTURER = "Intesis"
+
+CLOUD_CONFIGURATION_URL = "https://user.intesishome.com"

--- a/custom_components/intesishome/entity.py
+++ b/custom_components/intesishome/entity.py
@@ -1,0 +1,135 @@
+"""Shared entity plumbing for the IntesisHome integration.
+
+Every platform builds its device_info here so the climate entity and the
+diagnostic sensors always land on the same device registry entry. If each
+platform built its own, a single mismatched identifier would silently split
+one AC unit into two devices.
+"""
+from __future__ import annotations
+
+import logging
+
+from pyintesishome import IntesisBase
+from pyintesishome.const import DEVICE_INTESISBOX, DEVICE_INTESISHOME_LOCAL
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import CLOUD_CONFIGURATION_URL, DOMAIN, MANUFACTURER
+
+_LOGGER = logging.getLogger(__name__)
+
+LOCAL_DEVICE_TYPES = (DEVICE_INTESISHOME_LOCAL, DEVICE_INTESISBOX)
+
+
+def has_device_property(
+    controller: IntesisBase, device_id: str, prop: str
+) -> bool:
+    """Return True when the device advertises the given property.
+
+    Used to decide whether an entity should exist at all. IntesisHomeLocal
+    seeds a key for every datapoint the gateway advertises (see
+    ``get_datapoints``), and the cloud controllers populate their keys during
+    ``poll_status()`` -- which ``async_setup_entry`` has already awaited by the
+    time a platform is forwarded. So the device dict is authoritative for all
+    controller types, and reading it avoids having to special-case each one.
+
+    A hardware unit that does not support a datapoint never gets the key, so
+    the entity is not created rather than existing permanently unavailable.
+    """
+    return prop in (controller.get_device(device_id) or {})
+
+
+def build_device_info(
+    controller: IntesisBase,
+    device_id: str,
+    ih_device: dict,
+    host: str | None = None,
+) -> DeviceInfo:
+    """Build the device registry entry shared by every platform."""
+    # A two-element identifier, as DeviceInfo requires. controller_id is folded
+    # into the string rather than becoming a third tuple element so the same
+    # device id appearing under two different cloud accounts still resolves to
+    # two distinct devices.
+    identifier = f"{controller.controller_id}-{device_id}"
+
+    if controller.device_type in LOCAL_DEVICE_TYPES and host:
+        configuration_url = f"http://{host}"
+    else:
+        configuration_url = CLOUD_CONFIGURATION_URL
+
+    return DeviceInfo(
+        identifiers={(DOMAIN, identifier)},
+        # The fallback is load-bearing: with _attr_name = None on the climate
+        # entity, a device with no name renders its friendly name as the raw
+        # entity_id.
+        name=ih_device.get("name") or f"Intesis {device_id}",
+        manufacturer=MANUFACTURER,
+        model=controller.get_model(device_id),
+        sw_version=controller.get_fw_version(device_id),
+        configuration_url=configuration_url,
+    )
+
+
+class IntesisEntity(Entity):
+    """Base for every IntesisHome entity.
+
+    Owns the update-callback subscription so platforms do not each
+    reimplement it.
+    """
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        controller: IntesisBase,
+        device_id: str,
+        ih_device: dict,
+        host: str | None = None,
+    ) -> None:
+        """Initialise shared state."""
+        self._controller: IntesisBase = controller
+        self._device_id: str = str(device_id)
+        self._ih_device: dict = ih_device
+        self._device_name: str = ih_device.get("name")
+        self._device_type: str = controller.device_type
+        self._attr_device_info = build_device_info(
+            controller, device_id, ih_device, host
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to controller updates."""
+        self._controller.add_update_callback(self.async_update_callback)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Detach from the shared controller's update stream.
+
+        The controller's lifecycle is owned by the integration (constructed in
+        __init__.async_setup_entry, stopped in async_unload_entry) so an entity
+        must NOT call stop() here. Doing so would tear down the shared
+        controller when a single entity is removed or disabled, and would race
+        the integration-level stop on entry unload.
+        """
+        try:
+            self._controller.remove_update_callback(self.async_update_callback)
+        except ValueError:
+            # remove_update_callback is a bare list.remove(), which raises if
+            # the callback was never registered -- reachable when
+            # async_added_to_hass was interrupted.
+            pass
+
+    async def async_update_callback(self, device_id=None) -> None:
+        """Let HA know the controller has new data."""
+        if not device_id or self._device_id == str(device_id):
+            self.async_schedule_update_ha_state(True)
+
+    @property
+    def available(self) -> bool:
+        """Availability tracks the controller session, nothing else.
+
+        A value that is merely absent right now must stay available and
+        report None (rendered as "unknown"); flipping to unavailable would
+        break recorder statistics and fire unavailability automations.
+        """
+        return self._controller.is_connected

--- a/custom_components/intesishome/entity.py
+++ b/custom_components/intesishome/entity.py
@@ -67,6 +67,10 @@ def build_device_info(
         manufacturer=MANUFACTURER,
         model=controller.get_model(device_id),
         sw_version=controller.get_fw_version(device_id),
+        # For local gateways device_id is taken straight from the serial the
+        # device reports in getinfo, so this is the real serial rather than a
+        # synthesised one.
+        serial_number=str(device_id),
         configuration_url=configuration_url,
     )
 

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -1,12 +1,18 @@
 {
   "domain": "intesishome",
   "name": "IntesisHome",
-  "codeowners": ["@jnimmo"],
+  "codeowners": [
+    "@jnimmo"
+  ],
   "config_flow": true,
   "documentation": "https://github.com/jnimmo/hass-intesishome",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
-  "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==2.0.3"],
-  "version": "2.0.1-beta"
+  "loggers": [
+    "pyintesishome"
+  ],
+  "requirements": [
+    "pyintesishome==2.0.3"
+  ],
+  "version": "2.0.2-beta"
 }

--- a/custom_components/intesishome/sensor.py
+++ b/custom_components/intesishome/sensor.py
@@ -1,0 +1,146 @@
+"""Sensor platform for IntesisHome.
+
+Exposes readings the controller already fetches on every poll but which the
+climate entity either buries in attributes or discards. Nothing here opens its
+own connection -- every value comes from the shared controller in hass.data,
+which matters because some gateways (MH-AC-WIFI-1, for one) accept exactly one
+authenticated session and evict the previous one on any second login.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pyintesishome import IntesisBase
+
+from homeassistant import config_entries, core
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfTemperature,
+    UnitOfTime,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import IntesisEntity, has_device_property
+
+
+@dataclass(frozen=True, kw_only=True)
+class IntesisSensorEntityDescription(SensorEntityDescription):
+    """Describes an IntesisHome sensor."""
+
+    value_fn: Callable[[IntesisBase, str], Any]
+    # Device-dict key that must be advertised for this entity to be created.
+    required_property: str
+
+
+SENSOR_TYPES: tuple[IntesisSensorEntityDescription, ...] = (
+    IntesisSensorEntityDescription(
+        key="outdoor_temperature",
+        translation_key="outdoor_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        # Deliberately not diagnostic: this is a measurement of the world that
+        # people graph and drive automations from, not integration health.
+        required_property="outdoor_temp",
+        value_fn=lambda controller, device_id: controller.get_outdoor_temperature(
+            device_id
+        ),
+    ),
+    IntesisSensorEntityDescription(
+        key="run_hours",
+        translation_key="run_hours",
+        device_class=SensorDeviceClass.DURATION,
+        # Monotonic, with an implicit reset if the hardware is replaced.
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # DURATION ships no default icon.
+        icon="mdi:timer-outline",
+        required_property="working_hours",
+        value_fn=lambda controller, device_id: controller.get_run_hours(device_id),
+    ),
+    IntesisSensorEntityDescription(
+        key="error_code",
+        translation_key="error_code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # A bare vendor error number means nothing to most users -- the
+        # problem binary_sensor is the user-facing signal.
+        entity_registry_enabled_default=False,
+        icon="mdi:alert-circle-outline",
+        required_property="error_code",
+        # Reads the raw register rather than get_error(). The library's
+        # ERROR_MAP holds Panasonic Aquarea codes and maps 0 to
+        # "H00: No abnormality detected", so get_error() returns a truthy
+        # string when nothing is wrong, with text that is wrong for other
+        # manufacturers' hardware.
+        value_fn=lambda controller, device_id: controller.get_device_property(
+            device_id, "error_code"
+        ),
+    ),
+    IntesisSensorEntityDescription(
+        key="rssi",
+        translation_key="rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        required_property="rssi",
+        value_fn=lambda controller, device_id: controller.get_rssi(device_id),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create sensor entities for each datapoint the device advertises."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    controller: IntesisBase = entry_data["controller"]
+    host: str | None = entry_data["config"].get(CONF_HOST)
+
+    async_add_entities(
+        IntesisSensor(controller, device_id, ih_device, host, description)
+        for device_id, ih_device in (controller.get_devices() or {}).items()
+        for description in SENSOR_TYPES
+        if has_device_property(controller, device_id, description.required_property)
+    )
+
+
+class IntesisSensor(IntesisEntity, SensorEntity):
+    """A single reading from an Intesis controller."""
+
+    entity_description: IntesisSensorEntityDescription
+
+    def __init__(
+        self,
+        controller: IntesisBase,
+        device_id: str,
+        ih_device: dict,
+        host: str | None,
+        description: IntesisSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(controller, device_id, ih_device, host)
+        self.entity_description = description
+        # The climate entity's unique_id is the bare device_id, so a suffixed
+        # key can never collide with it.
+        self._attr_unique_id = f"{device_id}-{description.key}"
+
+    @property
+    def native_value(self) -> Any:
+        """Return the current reading, or None when it is not known yet."""
+        return self.entity_description.value_fn(self._controller, self._device_id)

--- a/custom_components/intesishome/strings.json
+++ b/custom_components/intesishome/strings.json
@@ -26,5 +26,29 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
+  },
+  "entity": {
+    "sensor": {
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "run_hours": {
+        "name": "Run hours"
+      },
+      "error_code": {
+        "name": "Error code"
+      },
+      "rssi": {
+        "name": "Signal strength"
+      }
+    },
+    "binary_sensor": {
+      "problem": {
+        "name": "Problem"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      }
+    }
   }
 }

--- a/custom_components/intesishome/translations/en.json
+++ b/custom_components/intesishome/translations/en.json
@@ -26,5 +26,29 @@
       "invalid_auth": "Invalid username or password.",
       "cannot_connect": "An error occurred connecting to the IntesisHome API."
     }
+  },
+  "entity": {
+    "sensor": {
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "run_hours": {
+        "name": "Run hours"
+      },
+      "error_code": {
+        "name": "Error code"
+      },
+      "rssi": {
+        "name": "Signal strength"
+      }
+    },
+    "binary_sensor": {
+      "problem": {
+        "name": "Problem"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      }
+    }
   }
 }


### PR DESCRIPTION
**Supersedes #47** (and therefore #28). Please close #47 in favour of this if you're happy with the approach.

Adds a device registry entry and two new platforms, so each AC unit becomes a proper HA **device** with the climate entity and diagnostic sensors grouped under it, showing model, firmware and serial number.

Tested end-to-end against a real MH-AC-WIFI-1 on a Mitsubishi Heavy split unit in **local** mode, on HA 2026.7.2 with pyintesishome 2.0.3.

---

### Includes #47, with three fixes

jnimmo's commit from `feat/device-registry` is cherry-picked first with authorship preserved, so the diff shows exactly what changed and why. It doesn't merge cleanly onto current `master` any more — #51 rewrote `target_temperature` underneath it — so the conflict is resolved here in favour of master's version.

Then three fixes on top:

1. **`identifiers` was a three-element tuple.** `DeviceInfo.identifiers` is typed `set[tuple[str, str]]`. There's no runtime arity check so it works today, but it's a typing violation and it breaks any `async_get_device({(DOMAIN, id)})` lookup. `controller_id` is now folded into the identifier string, which keeps the intent (disambiguating one device id across two cloud accounts) without violating the type.

   **This carries no migration cost** — the device_info was never released, so nobody has a three-element identifier in their registry. That's the argument for fixing it now rather than living with it.

2. **`manufacturer` rendered as "Intesishome_local"**, from `device_type.capitalize()`. `device_type` selects a transport, not a manufacturer — now hardcoded to `"Intesis"`.

3. **The `hasattr` guards were dead code.** `get_model` and `get_fw_version` have been on `IntesisBase` since well before 2.0.3.

Also adds `serial_number` and `configuration_url`, so the device page links straight to the gateway's own web UI (local) or the Intesis portal (cloud).

### New entities

| Entity | Platform | Notes |
| --- | --- | --- |
| Outdoor temperature | sensor | Not diagnostic — it's a measurement people graph and automate on. Still published as the `outdoor_temp` attribute for backwards compatibility |
| Run hours | sensor | `TOTAL_INCREASING`, diagnostic |
| Error code | sensor | Raw vendor code, diagnostic, disabled by default |
| Signal strength | sensor | Diagnostic, disabled by default |
| Problem | binary_sensor | From the `alarm_status` register |
| Connectivity | binary_sensor | From `controller.is_connected` |

The controller already fetched every one of these on each poll — `async_update` has been reading `get_rssi()` and `get_run_hours()` into instance attributes and discarding them. Attributes can't be graphed, don't get long-term statistics, and can't be targeted by automations the way entities can.

### Design notes

**Entities are only created when the device advertises the datapoint.** `has_device_property()` checks the device dict, which `IntesisHomeLocal.get_datapoints()` pre-seeds for every advertised uid and the cloud controllers populate during `poll_status()` — already awaited by the time platforms are forwarded. So one implementation serves local, cloud and IntesisBox with no `isinstance` checks.

A permanently-unavailable entity is worse than no entity: it pollutes entity pickers, warns in automations, and every user has to hide it by hand. Values that are merely *absent right now* still report `None` (rendered "unknown") and stay available — `available` tracks the controller session and nothing else, so recorder statistics don't get shredded every time a value blips.

**The error sensor reads the raw `error_code` register, not `get_error()`.** `ERROR_MAP` in pyintesishome is commented `# aquarea` and maps code `0` to `"H00: No abnormality detected"` — so `get_error()` returns a *truthy string when nothing is wrong*, and the text is wrong for non-Panasonic hardware. The `problem` binary_sensor uses the dedicated `alarm_status` register for the same reason. Happy to raise that as a library issue separately; I've left it alone here so this PR has no dependency on a pyintesishome release.

**Nothing opens its own connection.** Everything reads through the shared controller in `hass.data`. This matters more than it looks: the MH-AC-WIFI-1 accepts exactly **one** authenticated session and silently evicts the previous one on any second login. An entity doing its own HTTP would fight the integration's own 6-second poll.

**`has_entity_name` migration is a no-op, deliberately.** Climate gets `_attr_name = None` as the device's primary entity:

- `entity_id` is computed once at first registration and stored — existing installs keep `climate.<whatever>`.
- `friendly_name` becomes `device.name`, and the device name comes from the same `ih_device["name"]` the entity used before, so the rendered name is byte-identical.
- Verified on a live upgrade: the entity stayed `climate.device_01c1ca` / `"DEVICE_01C1CA"` throughout.

The one hazard is a device with a falsy name, where `_attr_name = None` would collapse the friendly name to the entity_id — guarded with an explicit fallback in `build_device_info`.

`unique_id` on the climate entity stays the bare `device_id`. It looks inconsistent next to the suffixed sensor keys and I've commented it as such, because changing it would orphan every existing user's climate entity along with its history and automations.

**Callbacks rather than a `DataUpdateCoordinator`.** A coordinator is the shape HA core would want and probably the right long-term move, but it would rewrite climate.py's entire update model in the same PR that adds two platforms. Happy to do it as a standalone follow-up.

One behavioural note: `_send_update_callback` awaits subscribers sequentially, so this goes from 1 to ~6 subscribers firing every 6s. Each callback body is a dict lookup, so it's immaterial at this scale, but worth knowing.

Also fixes a latent leak — `remove_update_callback` is a bare `list.remove()` and raises if the callback was never registered, reachable when `async_added_to_hass` is interrupted.

### Verified on hardware

Live MH-AC-WIFI-1 (17 datapoints), HA 2026.7.2:

```
climate.device_01c1ca                       off      <- entity_id and friendly_name unchanged
sensor.device_01c1ca_outdoor_temperature    22.0 °C
sensor.device_01c1ca_run_hours              38242 h
binary_sensor.device_01c1ca_connectivity    on
binary_sensor.device_01c1ca_problem         off
sensor.device_01c1ca_error_code             (created, disabled by default)
                                            (no signal strength entity - see below)

device: manufacturer=Intesis  model=MH-AC-WIFI-1  sw_version=1.2.0
        serial_number=CC3F1D01C1CA  configuration_url=http://192.168.1.242
        identifiers=[['intesishome', 'cc3f1d01c1ca-CC3F1D01C1CA']]
```

No signal strength entity is created on this hardware, which is the capability gate working correctly: `rssi` is uid 60002, a cloud-only pseudo-datapoint, and `_update_rssi()` is never called by `IntesisHomeLocal`. Local users get no RSSI today. The gateway's login-free `getinfo` *does* return live RSSI, so a library change could populate it — again, deliberately out of scope here.

`climate.set_temperature` round-tripped correctly after the refactor (22 → 23 → 22), and no tracebacks appear in the log across setup, polling and teardown.
