### PR TITLE
fix: surface unreachable local devices instead of ValueError (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage

--- a/custom_components/intesishome/__init__.py
+++ b/custom_components/intesishome/__init__.py
@@ -35,6 +35,22 @@ PLATFORMS = ["climate"]
 _LOGGER = logging.getLogger(__name__)
 
 
+def controller_identity(controller: IntesisBase) -> str | None:
+    """Return the controller's identity, or None if it was never set.
+
+    pyintesishome only populates the controller id once it has identified the
+    device, and raises ValueError from the property until then. Since
+    pyintesishome 2.1.0 an unreachable local device raises IHConnectionError
+    rather than returning without an id, so this covers the narrower cases: an
+    IntesisBox that connected without returning an ID, or a getinfo response
+    with no serial number.
+    """
+    try:
+        return controller.controller_id
+    except ValueError:
+        return None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up IntesisHome from a config entry.
 
@@ -80,6 +96,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except IHConnectionError as exc:
         _LOGGER.error("Error connecting to the %s server: %s", device_type, exc)
         raise ConfigEntryNotReady from exc
+
+    # connect() raises on an unreachable device, so reaching here means the
+    # connection came up. An identity can still be missing if the device
+    # answered without one - setting up entities against that produces a
+    # permanently broken entry, so bail out and let HA retry instead.
+    # error_message is only ever populated by the cloud controller, so it is
+    # deliberately not logged here.
+    if not controller_identity(controller):
+        await controller.stop()
+        _LOGGER.error(
+            "%s at %s connected but returned no device identity",
+            device_type,
+            ih_host or ih_user,
+        )
+        raise ConfigEntryNotReady("Device did not return an identity")
 
     if not controller.get_devices():
         await controller.stop()

--- a/custom_components/intesishome/config_flow.py
+++ b/custom_components/intesishome/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_PASSWORD, CONF_USER
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from . import DOMAIN
+from . import DOMAIN, controller_identity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,7 +132,21 @@ class IntesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     await controller.poll_status()
 
-                if len(controller.get_devices()) == 0:
+                # As of pyintesishome 2.1.0 an unreachable device raises, so
+                # we only get here on a successful connection. controller_id
+                # still raises ValueError until the device has been identified
+                # though, so guard it rather than letting that surface as an
+                # "unknown error" - it covers an IntesisBox that connected
+                # without returning an ID, and a getinfo response with no
+                # serial number.
+                if not controller_identity(controller):
+                    _LOGGER.error(
+                        "No identity returned from %s - check the device is "
+                        "reachable and its local API is enabled",
+                        user_input.get(CONF_HOST, device_type),
+                    )
+                    errors["base"] = "cannot_connect"
+                elif len(controller.get_devices()) == 0:
                     errors["base"] = "no_devices"
                 else:
                     unique_id = (

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==2.0.3"],
-  "version": "2.0.1-beta"
+  "requirements": ["pyintesishome==2.1.0"],
+  "version": "2.0.2-beta"
 }


### PR DESCRIPTION
Fixes #55

## Problem

An unreachable IntesisHome Local device (one MH-AC-WIFI-1 of five, the other four working) failed the config flow with an "unknown error" and a `ValueError` traceback rather than a usable message.

With `pyintesishome==2.0.3`, `IntesisHomeLocal.poll_status()` logged connection and authentication failures rather than raising them, so it returned cleanly even when the device never responded. That left the controller in a half-valid state:

- `_controller_id` was never assigned, and `controller_id` raises `ValueError: Controller ID has not been set yet` until it is
- but `poll_status()` had already run `self._devices[self._device_id] = {...}` with `_device_id` still `""`, registering a placeholder device

So the existing `len(get_devices()) == 0` guard passed — it was 1, the placeholder — and the next line read `controller_id` and raised. `async_setup_entry` would likewise have built climate entities against the placeholder instead of retrying.

Reproduced against 2.0.3 with a timing-out websession:

```
get_devices() -> {'': {'name': None, 'widgets': [], 'model': None, ...}}
len(get_devices()) -> 1
controller_id -> raised ValueError: Controller ID has not been set yet
```

The reporter's `/api.cgi` theory is a red herring worth recording: `/api.cgi` is the only local endpoint in the library, and it is used *before* `getinfo` returns the device model, so it cannot be branching on model. A wrong endpoint would 404 promptly and log `Error during polling status`; the timeout they saw means something accepted the connection and never answered.

## Root cause is fixed upstream

Reported as jnimmo/pyIntesisHome#79 and released in **pyintesishome 2.1.0**:

- `poll_status()` raises `IHConnectionError` when the device can't be reached, and registers no device
- `_authenticate()` raises `IHConnectionError` when unreachable and `IHAuthenticationError` when the credentials are rejected
- a rejected login no longer raises `TypeError` while parsing the `data: null` response, and the auth request now uses the same 10s timeout as every other local request

The handlers for both exceptions already existed in this integration, so the pin bump alone makes an unreachable device report `cannot_connect` and a rejected login report `invalid_auth`.

**`invalid_auth` newly works for local devices.** Previously a rejected local login logged "Unexpected response format", never raised, and fell into the same placeholder-device path — a wrong password was indistinguishable from an unreachable device. Now the config flow shows "Invalid username or password", and `async_setup_entry` raises `ConfigEntryAuthFailed`, which gets the user a re-auth prompt instead of a silent retry loop. Both handlers were effectively dead code for local devices until this release.

## Changes

- **`manifest.json`** — pin `pyintesishome==2.1.0`; integration version to `2.0.2-beta`.
- **`__init__.py`** — new `controller_identity()` helper turning the raising property into `None`; `async_setup_entry` raises `ConfigEntryNotReady` when the controller connects but returns no identity.
- **`config_flow.py`** — check the identity before using it and report `cannot_connect`, with a log naming the host.
- **`.gitignore`** — added; the repo had none.

The `controller_identity()` guard is retained as a fallback for the two cases the library fix doesn't cover: an `IntesisBox` that connects without returning an ID (`_controller_id` is only set when the ID response is parsed), and a `getinfo` response carrying no serial number.

Safe across controller types — cloud `IntesisHome` sets `_controller_id = username` in its constructor, so it is always truthy and this path is unreachable for it.

## Notes from the 2.1.0 audit

- **No translation changes.** Both `strings.json` and `en.json` already carry `cannot_connect` and `invalid_auth`.
- **`except` ordering is safe.** `IHAuthenticationError` subclasses the *builtin* `ConnectionError`, not `IHConnectionError` — they are unrelated classes, so neither ordering shadows the other.
- **`climate.py` is unaffected.** `async_update()` only copies cached values off the controller dict, and `should_poll` is `False`, so nothing there can now raise.
- **Dropped `controller.error_message` from the identity-failure log.** `_error_message` is only ever assigned by the cloud controller, so it was always `None` on the paths that can reach that branch.

## Scope

This does not make the reporter's fifth unit work. Their module accepts TCP connections and then never answers `/api.cgi` while still serving static files — a wedged gateway that needs a power cycle. This PR only ensures the failure is reported accurately instead of as an unknown error.

Known limitation, not addressed here: jnimmo/pyIntesisHome#80 — for local devices `is_connected` never becomes `False` after setup, so a unit that dies mid-run keeps its entity `available` with stale values. That needs a library fix; this component has no signal it could act on. Once fixed, the `available` logic already in `climate.py` starts working with no change here.

## Testing

Verified by simulating the failure against the real library with a stubbed websession, and re-verified against 2.1.0. Regression tests for the library-side paths live upstream with the fix (jnimmo/pyIntesisHome#79); no automated tests are added here, as this repo has no test infrastructure and CI runs only HACS validation and hassfest.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Shk5FbeuNFnswHRa5LYGL)_