### PR TITLE
chore: require pyintesishome 2.2.0

### DIFF
--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==2.1.0"],
+  "requirements": ["pyintesishome==2.2.0"],
   "version": "2.0.2-beta"
 }


### PR DESCRIPTION
2.2.0 makes IntesisHomeLocal.is_connected reflect whether the device is actually reachable. It previously only ever meant "connect() succeeded once and stop() hasn't been called", so a local unit that died after setup kept its entity available and serving the last values it managed to read.

No integration changes are needed. The updater still fires an update callback on every tick, including failed ones, so the transition tracking in IntesisClimate.async_update_callback and the available property both start working as already written - a device is reported unavailable after five minutes without a successful poll, and recovers on its own when it starts answering again.

The integration version stays at 2.0.2-beta, which has not been tagged yet, so this ships as part of that release rather than as a new one.