### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
   "requirements": ["pyintesishome==2.2.0"],
-  "version": "2.0.3-beta"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Summary
- Bumps `manifest.json`'s `version` to `2.1.0` ahead of tagging the release covering #53, #57, #58, #59, #60, #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)