### PR TITLE
Add button and switch platforms and include filter status sensors

### DIFF
--- a/custom_components/intesishome/binary_sensor.py
+++ b/custom_components/intesishome/binary_sensor.py
@@ -57,6 +57,17 @@ BINARY_SENSOR_TYPES: tuple[IntesisBinarySensorEntityDescription, ...] = (
         always_available=True,
         value_fn=lambda controller, device_id: controller.is_connected,
     ),
+    IntesisBinarySensorEntityDescription(
+        key="filter_clean",
+        translation_key="filter_clean",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:air-filter",
+        required_property="filter_clean",
+        value_fn=lambda controller, device_id: bool(
+            controller.get_device_property(device_id, "filter_clean")
+        ),
+    ),
 )
 
 

--- a/custom_components/intesishome/button.py
+++ b/custom_components/intesishome/button.py
@@ -1,0 +1,81 @@
+"""Button platform for IntesisHome."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pyintesishome import IntesisBase
+
+from homeassistant import config_entries, core
+from homeassistant.components.button import (
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.const import CONF_HOST, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import IntesisEntity, has_device_property
+
+
+@dataclass(frozen=True, kw_only=True)
+class IntesisButtonEntityDescription(ButtonEntityDescription):
+    """Describes an IntesisHome button."""
+
+    press_fn: Callable[[IntesisBase, str], Awaitable[bool]]
+    required_property: str
+
+
+BUTTON_TYPES: tuple[IntesisButtonEntityDescription, ...] = (
+    IntesisButtonEntityDescription(
+        key="reset_filter",
+        translation_key="reset_filter",
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:filter-remove",
+        required_property="filter_clean",
+        press_fn=lambda controller, device_id: controller._set_value(
+            device_id, 183, 1
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create button entities for each datapoint the device advertises."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    controller: IntesisBase = entry_data["controller"]
+    host: str | None = entry_data["config"].get(CONF_HOST)
+
+    async_add_entities(
+        IntesisButton(controller, device_id, ih_device, host, description)
+        for device_id, ih_device in (controller.get_devices() or {}).items()
+        for description in BUTTON_TYPES
+        if has_device_property(controller, device_id, description.required_property)
+    )
+
+
+class IntesisButton(IntesisEntity, ButtonEntity):
+    """A button entity for an Intesis controller."""
+
+    entity_description: IntesisButtonEntityDescription
+
+    def __init__(
+        self,
+        controller: IntesisBase,
+        device_id: str,
+        ih_device: dict,
+        host: str | None,
+        description: IntesisButtonEntityDescription,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(controller, device_id, ih_device, host)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}-{description.key}"
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.entity_description.press_fn(self._controller, self._device_id)

--- a/custom_components/intesishome/button.py
+++ b/custom_components/intesishome/button.py
@@ -34,7 +34,7 @@ BUTTON_TYPES: tuple[IntesisButtonEntityDescription, ...] = (
         icon="mdi:filter-remove",
         required_property="filter_clean",
         press_fn=lambda controller, device_id: controller._set_value(
-            device_id, 183, 1
+            device_id, 184, 0
         ),
     ),
 )

--- a/custom_components/intesishome/const.py
+++ b/custom_components/intesishome/const.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 DOMAIN = "intesishome"
 
-PLATFORMS: list[str] = ["binary_sensor", "climate", "sensor"]
+PLATFORMS: list[str] = ["binary_sensor", "button", "climate", "sensor", "switch"]
 
 # The device_type reported by the library ("intesishome", "intesishome_local",
 # "intesisbox", "airconwithme") describes the transport, not who made the

--- a/custom_components/intesishome/sensor.py
+++ b/custom_components/intesishome/sensor.py
@@ -99,6 +99,19 @@ SENSOR_TYPES: tuple[IntesisSensorEntityDescription, ...] = (
         required_property="rssi",
         value_fn=lambda controller, device_id: controller.get_rssi(device_id),
     ),
+    IntesisSensorEntityDescription(
+        key="filter_due_hours",
+        translation_key="filter_due_hours",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:filter-outline",
+        required_property="filter_due_hours",
+        value_fn=lambda controller, device_id: controller.get_device_property(
+            device_id, "filter_due_hours"
+        ),
+    ),
 )
 
 

--- a/custom_components/intesishome/strings.json
+++ b/custom_components/intesishome/strings.json
@@ -48,6 +48,9 @@
       },
       "rssi": {
         "name": "Signal strength"
+      },
+      "filter_due_hours": {
+        "name": "Filter due hours"
       }
     },
     "binary_sensor": {
@@ -56,6 +59,19 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "filter_clean": {
+        "name": "Filter clean required"
+      }
+    },
+    "button": {
+      "reset_filter": {
+        "name": "Reset filter"
+      }
+    },
+    "switch": {
+      "remote_controller_lock": {
+        "name": "Remote controller lock"
       }
     }
   }

--- a/custom_components/intesishome/switch.py
+++ b/custom_components/intesishome/switch.py
@@ -1,0 +1,100 @@
+"""Switch platform for IntesisHome."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pyintesishome import IntesisBase
+
+from homeassistant import config_entries, core
+from homeassistant.components.switch import (
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.const import CONF_HOST, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import IntesisEntity, has_device_property
+
+
+@dataclass(frozen=True, kw_only=True)
+class IntesisSwitchEntityDescription(SwitchEntityDescription):
+    """Describes an IntesisHome switch."""
+
+    is_on_fn: Callable[[IntesisBase, str], bool | None]
+    turn_on_fn: Callable[[IntesisBase, str], Awaitable[bool]]
+    turn_off_fn: Callable[[IntesisBase, str], Awaitable[bool]]
+    required_property: str
+
+
+SWITCH_TYPES: tuple[IntesisSwitchEntityDescription, ...] = (
+    IntesisSwitchEntityDescription(
+        key="remote_controller_lock",
+        translation_key="remote_controller_lock",
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:remote-off",
+        required_property="remote_controller_lock",
+        is_on_fn=lambda controller, device_id: controller.get_device_property(
+            device_id, "remote_controller_lock"
+        )
+        == 1,
+        turn_on_fn=lambda controller, device_id: controller._set_value(
+            device_id, 12, 1
+        ),
+        turn_off_fn=lambda controller, device_id: controller._set_value(
+            device_id, 12, 0
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create switch entities for each datapoint the device advertises."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    controller: IntesisBase = entry_data["controller"]
+    host: str | None = entry_data["config"].get(CONF_HOST)
+
+    async_add_entities(
+        IntesisSwitch(controller, device_id, ih_device, host, description)
+        for device_id, ih_device in (controller.get_devices() or {}).items()
+        for description in SWITCH_TYPES
+        if has_device_property(controller, device_id, description.required_property)
+    )
+
+
+class IntesisSwitch(IntesisEntity, SwitchEntity):
+    """A switch entity for an Intesis controller."""
+
+    entity_description: IntesisSwitchEntityDescription
+
+    def __init__(
+        self,
+        controller: IntesisBase,
+        device_id: str,
+        ih_device: dict,
+        host: str | None,
+        description: IntesisSwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(controller, device_id, ih_device, host)
+        self.entity_description = description
+        self._attr_unique_id = f"{device_id}-{description.key}"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if switch is on."""
+        return self.entity_description.is_on_fn(self._controller, self._device_id)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self.entity_description.turn_on_fn(self._controller, self._device_id)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self.entity_description.turn_off_fn(self._controller, self._device_id)

--- a/custom_components/intesishome/translations/en.json
+++ b/custom_components/intesishome/translations/en.json
@@ -48,6 +48,9 @@
       },
       "rssi": {
         "name": "Signal strength"
+      },
+      "filter_due_hours": {
+        "name": "Filter due hours"
       }
     },
     "binary_sensor": {
@@ -56,6 +59,19 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "filter_clean": {
+        "name": "Filter clean required"
+      }
+    },
+    "button": {
+      "reset_filter": {
+        "name": "Reset filter"
+      }
+    },
+    "switch": {
+      "remote_controller_lock": {
+        "name": "Remote controller lock"
       }
     }
   }


### PR DESCRIPTION
Continue fine work by [coldreckon](https://github.com/coldreckon) in  https://github.com/jnimmo/hass-intesishome/pull/53 to include filter maintenance sensors. Introduce `button.py` and `switch.py` to complete local device capabilities:

- **`sensor.py`**: Adds `filter_due_hours` sensor (UID 184).
- **`binary_sensor.py`**: Adds `filter_clean` problem sensor (UID 183).
 - **`button.py`**: Adds `reset_filter` button (UID 183) to reset filter timer.
- **`switch.py`**: Adds `remote_controller_lock` switch (UID 12) to lock/unlock physical remote controls.
- **`const.py`**: Registered `button` and `switch` and added translation strings to `strings.json` and `translations/en.json`.

Verified live on a local `MH-AC-WIFI-1` unit with Home Assistant 2026.7.4.