### PR TITLE
Gate availability on is_available for pyintesishome 2.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,15 @@ checks either way.
   Entities must **never** call `controller.stop()` themselves; the controller's lifecycle belongs to
   the integration (`async_unload_entry`), and stopping it from an entity would tear down the shared
   session for every other entity on the config entry.
-- A default `available` that tracks `controller.is_connected` and nothing else. A datapoint that's
-  merely absent right now should still report `None` ("unknown") and stay *available* — flipping to
-  unavailable on a transient missing value would shred recorder long-term statistics and fire
-  unavailability automations unnecessarily. `climate.py`'s `IntesisAC` overrides this with its own
-  cached `_connected` flag (predates the shared base) rather than using the live property directly.
+- A default `available` that tracks `controller.is_available` and nothing else — every platform,
+  `climate.py` included, inherits it. **Never gate availability on `is_connected`**: since
+  pyintesishome 2.3.0 the cloud push socket is opened only to carry commands and is deliberately not
+  reconnected when it drops, so `is_connected` is `False` in normal operation while state keeps
+  arriving over HTTPS polling. `is_available` is true while either the socket is up or a recent poll
+  succeeded. `IntesisAC` still keeps a cached `_available` flag, but only to detect transitions for
+  logging — not to answer `available`. A datapoint that's merely absent right now should still report
+  `None` ("unknown") and stay *available* — flipping to unavailable on a transient missing value would
+  shred recorder long-term statistics and fire unavailability automations unnecessarily.
 
 `climate.py`'s `IntesisAC` sets `_attr_name = None` (the HA "primary entity" pattern) so it inherits
 the device's own name for `friendly_name`, while `entity_id` stays whatever was already registered —

--- a/custom_components/intesishome/binary_sensor.py
+++ b/custom_components/intesishome/binary_sensor.py
@@ -55,7 +55,11 @@ BINARY_SENSOR_TYPES: tuple[IntesisBinarySensorEntityDescription, ...] = (
         # A connectivity sensor that goes unavailable when the connection
         # drops reports nothing at exactly the moment it is needed.
         always_available=True,
-        value_fn=lambda controller, device_id: controller.is_connected,
+        # is_available, not is_connected: the cloud push socket is opened
+        # only for commands and left down the rest of the time, so
+        # is_connected here would report "disconnected" on a perfectly
+        # healthy account that is being polled over HTTPS.
+        value_fn=lambda controller, device_id: controller.is_available,
     ),
     IntesisBinarySensorEntityDescription(
         key="filter_clean",

--- a/custom_components/intesishome/climate.py
+++ b/custom_components/intesishome/climate.py
@@ -114,7 +114,7 @@ class IntesisAC(IntesisEntity, ClimateEntity):
         """Initialize the thermostat."""
         super().__init__(controller, ih_device_id, ih_device, host)
         self._host: str | None = host
-        self._connected: bool = False
+        self._available: bool = False
         self._setpoint_step: float = 1.0
         self._current_temp: float = None
         self._max_temp: float = None
@@ -350,7 +350,7 @@ class IntesisAC(IntesisEntity, ClimateEntity):
     async def async_update(self):
         """Copy values from controller dictionary to climate device."""
         # Update values from controller's device dictionary
-        self._connected = self._controller.is_connected
+        self._available = self._controller.is_available
         self._current_temp = self._controller.get_temperature(self._device_id)
         self._fan_speed = self._controller.get_fan_speed(self._device_id)
         self._power = self._controller.is_on(self._device_id)
@@ -403,13 +403,17 @@ class IntesisAC(IntesisEntity, ClimateEntity):
 
     async def async_update_callback(self, device_id=None):
         """Let HA know there has been an update from the controller."""
-        # Track connection-state transitions for logging.
-        if self._controller and not self._controller.is_connected and self._connected:
-            self._connected = False
-            _LOGGER.info("Connection to %s API was lost", self._device_type)
-        elif self._controller and self._controller.is_connected and not self._connected:
-            self._connected = True
-            _LOGGER.debug("Connection to %s API was restored", self._device_type)
+        # Track availability transitions for logging. This follows
+        # is_available rather than is_connected so it logs when state
+        # actually stops arriving, not on every cloud push-socket drop --
+        # those are routine since pyintesishome 2.3.0 stopped reconnecting
+        # the socket and moved state onto HTTPS polling.
+        if self._controller and not self._controller.is_available and self._available:
+            self._available = False
+            _LOGGER.info("No longer receiving state from the %s API", self._device_type)
+        elif self._controller and self._controller.is_available and not self._available:
+            self._available = True
+            _LOGGER.debug("Receiving state from the %s API again", self._device_type)
 
         await super().async_update_callback(device_id)
 
@@ -457,10 +461,11 @@ class IntesisAC(IntesisEntity, ClimateEntity):
         """List of available horizontal swing positions."""
         return self._swing_horizontal_list
 
-    @property
-    def available(self) -> bool:
-        """If the device hasn't been able to connect, mark as unavailable."""
-        return self._connected or self._connected is None
+    # No `available` override: IntesisEntity.available reads
+    # controller.is_available live. The old override served a cached
+    # `_connected` flag that could only be refreshed by an update, so an
+    # entity that stopped receiving updates kept reporting available. The
+    # cached flag survives purely to detect transitions for logging.
 
     @property
     def current_temperature(self) -> float | None:

--- a/custom_components/intesishome/entity.py
+++ b/custom_components/intesishome/entity.py
@@ -130,10 +130,17 @@ class IntesisEntity(Entity):
 
     @property
     def available(self) -> bool:
-        """Availability tracks the controller session, nothing else.
+        """Availability tracks the controller's path to the device.
+
+        Gated on is_available, not is_connected: since pyintesishome 2.3.0
+        the cloud push socket is opened only to carry commands and is not
+        reconnected when it drops, so is_connected is False during normal
+        operation. is_available is True while either the socket is up or a
+        recent HTTP poll succeeded, which is what "we still have current
+        state for this device" actually means.
 
         A value that is merely absent right now must stay available and
         report None (rendered as "unknown"); flipping to unavailable would
         break recorder statistics and fire unavailability automations.
         """
-        return self._controller.is_connected
+        return self._controller.is_available

--- a/custom_components/intesishome/manifest.json
+++ b/custom_components/intesishome/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jnimmo/hass-intesishome/issues",
   "loggers": ["pyintesishome"],
-  "requirements": ["pyintesishome==2.2.0"],
-  "version": "2.2.0"
+  "requirements": ["pyintesishome==2.3.0"],
+  "version": "2.3.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
 pytest-homeassistant-custom-component
-pyintesishome==2.2.0
+pyintesishome==2.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,11 @@ def mock_controller() -> Generator[MagicMock]:
         controller.device_type = "IntesisHome"
         controller.controller_id = MOCK_CONTROLLER_ID
         controller.name = MOCK_DEVICE_NAME
-        controller.is_connected = True
+        # is_available is what entities gate on; is_connected is only the
+        # raw push-socket state and is False in normal operation since
+        # pyintesishome 2.3.0.
+        controller.is_available = True
+        controller.is_connected = False
         controller.error_message = None
 
         controller.get_devices.return_value = {MOCK_DEVICE_ID: MOCK_DEVICE}

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -19,7 +19,13 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, Platform, STATE_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    Platform,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -44,6 +50,32 @@ async def test_entities(
     await snapshot_platform(
         hass, entity_registry, snapshot, mock_config_entry.entry_id
     )
+
+
+async def test_available_while_socket_is_down(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """A closed push socket alone must not make the entity unavailable.
+
+    This is the regression guard for #50: since pyintesishome 2.3.0 the cloud
+    socket is opened only for commands and never reconnected, so is_connected
+    is False on a perfectly healthy account whose state arrives via polling.
+    """
+    mock_controller.is_connected = False
+    mock_controller.is_available = True
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(ENTITY_ID).state != STATE_UNAVAILABLE
+
+
+async def test_unavailable_when_state_stops_arriving(
+    hass: HomeAssistant, mock_controller: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """is_available going False does make the entity unavailable."""
+    mock_controller.is_available = False
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
 
 
 async def test_supported_features_minimal(


### PR DESCRIPTION
pyintesishome 2.3.0 moves cloud state onto HTTPS polling. The push socket is now opened only to carry commands and is deliberately not reconnected when it drops, so is_connected is False during normal operation. Every entity gating availability on it would go unavailable on a perfectly healthy account - the bug reported in #50.

Gate on the new is_available instead (true while either the socket is up or a recent poll succeeded), and bump the pin to 2.3.0.

IntesisAC's available override is removed rather than repointed. It served a cached flag refreshed only by an update, so an entity that stopped receiving updates kept reporting available - exactly backwards under the new model. The cached flag survives, renamed _available, purely to detect transitions for logging.

The connectivity binary_sensor reads is_available too; on is_connected it would report "disconnected" whenever no command happened to be in flight.